### PR TITLE
feat(Command): CommandBuilders

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,7 @@ module.exports = {
     GDMChannel: require('./structures/DMChannel'),
     GThreadChannel: require('./structures/ThreadChannel'),
     CommandBuilder: require('./structures/CommandBuilder'),
+    CommandArgBuilder: require('./structures/CommandArgBuilder'),
     MessageButton: require('./structures/MessageButton'),
     MessageActionRow: require('./structures/MessageActionRow'),
     MessageSelectMenu: require('./structures/MessageSelectMenu'),

--- a/src/index.js
+++ b/src/index.js
@@ -18,6 +18,7 @@ module.exports = {
     GTextChannel: require('./structures/TextChannel'),
     GDMChannel: require('./structures/DMChannel'),
     GThreadChannel: require('./structures/ThreadChannel'),
+    CommandBuilder: require('./structures/CommandBuilder'),
     MessageButton: require('./structures/MessageButton'),
     MessageActionRow: require('./structures/MessageActionRow'),
     MessageSelectMenu: require('./structures/MessageSelectMenu'),

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,7 @@ module.exports = {
     GThreadChannel: require('./structures/ThreadChannel'),
     CommandBuilder: require('./structures/CommandBuilder'),
     CommandArgBuilder: require('./structures/CommandArgBuilder'),
+    CommandArgChoiceBuilder: require('./structures/CommandArgChoiceBuilder'),
     MessageButton: require('./structures/MessageButton'),
     MessageActionRow: require('./structures/MessageActionRow'),
     MessageSelectMenu: require('./structures/MessageSelectMenu'),

--- a/src/structures/CommandArgBuilder.js
+++ b/src/structures/CommandArgBuilder.js
@@ -1,0 +1,138 @@
+const { resolveString } = require('../util/util');
+
+/**
+ * The CommandArgBuilder class
+ */
+class CommandArgBuilder {
+    /**
+     * Creates new CommandArgBuilder instance
+     * @param {Object} data
+    */
+    constructor(data = {}) {
+        this.setup(data);
+    }
+
+    /**
+     * Setup
+     * @param {Object} data
+     * @returns {CommandArgsOption}
+     * @private
+     */
+    setup(data) {
+        /**
+         * Name
+         * @type {string}
+        */
+        this.name = 'name' in data ? resolveString(data.name) : null;
+
+        /**
+         * Description
+         * @type {string}
+        */
+        this.description = 'description' in data ? resolveString(data.description) : null;
+
+        /**
+         * Type
+         * @type {Number}
+        */
+        this.type = 'type' in data ? Number(data.type) : null;
+
+        /**
+         * Prompt
+         * @type {string}
+        */
+        this.prompt = 'prompt' in data ? resolveString(data.prompt) : null;
+
+        /**
+         * Required
+         * @type {Boolean}
+        */
+        this.required = 'required' in data ? Boolean(data.required) : null;
+
+        /**
+         * Choices
+         * @type {}
+        */
+        this.choices = 'choices' in data ? data.choises : null;
+
+        return this.toJSON();
+    }
+
+    /**
+     * Method to setName
+     * @param {String} name
+    */
+    setName(name) {
+        this.name = resolveString(name);
+        return this;
+    }
+
+    /**
+     * Method to setDescription
+     * @param {String} description
+    */
+    setDescription(description) {
+        this.description = resolveString(description);
+        return this;
+    }
+
+    /**
+     * Method to setType
+     * @param {String} type
+    */
+    setType(type) {
+        this.type = Number(type);
+        return this;
+    }
+
+    /**
+     * Method to setPrompt
+     * @param {String} prompt
+    */
+    setPrompt(prompt) {
+        this.prompt = resolveString(prompt);
+        return this;
+    }
+
+    /**
+     * Method to setRequired
+     * @param {Boolean} required
+    */
+    setRequired(required) {
+        this.required = Boolean(required);
+        return this;
+    }
+
+    /**
+     * Method to addChoice
+     * @param {CommandArgsChoice} choice
+    */
+    addChoice() {
+        return this;
+    }
+
+    /**
+     * Method to addChoices
+     * @param {Array<CommandArgsChoice>} choices
+    */
+    addChoices() {
+        return this;
+    }
+
+    /**
+     * Method to toJSON
+     * @returns {Object}
+    */
+     toJSON() {
+        return {
+          name: this.name,
+          description: this.description,
+          type: this.type,
+          prompt: this.prompt,
+          required: this.required,
+          choises: this.choices,
+        };
+      }
+}
+
+module.exports = CommandArgBuilder;

--- a/src/structures/CommandArgBuilder.js
+++ b/src/structures/CommandArgBuilder.js
@@ -107,7 +107,9 @@ class CommandArgBuilder {
      * Method to addChoice
      * @param {CommandArgsChoice} choice
     */
-    addChoice() {
+    addChoice(choice) {
+        if (!Array.isArray(this.choices)) this.choices = [];
+        this.choices.push(choice);
         return this;
     }
 
@@ -115,7 +117,10 @@ class CommandArgBuilder {
      * Method to addChoices
      * @param {Array<CommandArgsChoice>} choices
     */
-    addChoices() {
+    addChoices(choices) {
+        for (const choice of Object.values(choices)) {
+            this.addChoice(choice);
+        }
         return this;
     }
 

--- a/src/structures/CommandArgBuilder.js
+++ b/src/structures/CommandArgBuilder.js
@@ -51,9 +51,15 @@ class CommandArgBuilder {
 
         /**
          * Choices
-         * @type {}
+         * @type {Array<CommandArgsChoice>}
         */
         this.choices = 'choices' in data ? data.choises : null;
+
+        /**
+         * Args
+         * @type {Array<CommandArgsOption>}
+        */
+         this.args = 'args' in data ? data.args : null;
 
         return this.toJSON();
     }
@@ -123,6 +129,27 @@ class CommandArgBuilder {
         }
         return this;
     }
+
+    /**
+     * Method to addArg
+     * @param {CommandArgsOption} arg
+    */
+     addArg(arg) {
+        if (!Array.isArray(this.args)) this.args = [];
+        this.args.push(arg);
+        return this;
+      }
+
+      /**
+       * Method to addArgs
+       * @param {Array<CommandArgsOption>} args
+      */
+      addArgs(args) {
+        for (const arg of Object.values(args)) {
+          this.addArg(arg);
+        }
+        return this;
+      }
 
     /**
      * Method to toJSON

--- a/src/structures/CommandArgChoiceBuilder.js
+++ b/src/structures/CommandArgChoiceBuilder.js
@@ -1,0 +1,61 @@
+const { resolveString } = require('../util/util');
+
+/**
+ * The CommandArgChoiceBuilder class
+ */
+class CommandArgChoiceBuilder {
+    /**
+     * Creates new CommandArgChoiceBuilder instance
+     * @param {Object} data
+    */
+     constructor(data = {}) {
+        this.setup(data);
+    }
+
+    setup(data) {
+        /**
+         * Name
+         * @type {string}
+        */
+        this.name = 'name' in data ? resolveString(data.name) : null;
+
+        /**
+         * Value
+         * @type {any}
+        */
+        this.value = 'value' in data ? data.value : null;
+
+        return this.toJSON();
+    }
+
+    /**
+     * Method to setName
+     * @param {String} name
+    */
+    setName(name) {
+        this.name = resolveString(name);
+        return this;
+    }
+
+    /**
+     * Method to setValue
+     * @param {any} value
+    */
+    setValue(value) {
+        this.value = value;
+        return this;
+    }
+
+    /**
+     * Method to toJSON
+     * @returns {Object}
+    */
+     toJSON() {
+        return {
+          name: this.name,
+          value: this.value,
+        };
+      }
+}
+
+module.exports = CommandArgChoiceBuilder;

--- a/src/structures/CommandBuilder.js
+++ b/src/structures/CommandBuilder.js
@@ -39,7 +39,7 @@ class CommandBuilder {
 
        /**
          * Args
-         * @type {Array}
+         * @type {Array<CommandArgsOption>}
         */
        this.args = 'args' in data ? data.args : null;
 
@@ -164,11 +164,25 @@ class CommandBuilder {
     }
 
     /**
-     * Method to setArgs
-     * @param {Array} args
+     * Method to addArg
+     * @param {CommandArgsChoice} arg
     */
-    setArgs(args) {
-      this.args = args;
+    addArg(arg) {
+      if (!Array.isArray(this.args)) this.args = [];
+      this.args.push(arg);
+      console.log(this.args);
+      return this;
+    }
+
+    /**
+     * Method to addArgs
+     * @param {Array<CommandArgsChoice>} args
+    */
+    addArgs(args) {
+      if (!Array.isArray(this.args)) this.args = [];
+      for (const arg of Object.values(args)) {
+        this.args.push(arg);
+      }
       return this;
     }
 
@@ -258,7 +272,7 @@ class CommandBuilder {
      * @param {Boolean} channelTextOnly
     */
     setChannelTextOnly(channelTextOnly) {
-      this.channelTextOnly = channelTextOnly;
+      this.channelTextOnly = Boolean(channelTextOnly);
       return this;
     }
 
@@ -267,7 +281,7 @@ class CommandBuilder {
      * @param {Boolean} channelNewsOnly
     */
     setChannelNewsOnly(channelNewsOnly) {
-      this.channelNewsOnly = channelNewsOnly;
+      this.channelNewsOnly = Boolean(channelNewsOnly);
       return this;
     }
 
@@ -276,7 +290,7 @@ class CommandBuilder {
      * @param {Boolean} channelThreadOnly
     */
     setChannelThreadOnly(channelThreadOnly) {
-      this.channelThreadOnly = channelThreadOnly;
+      this.channelThreadOnly = Boolean(channelThreadOnly);
       return this;
     }
 
@@ -285,7 +299,7 @@ class CommandBuilder {
      * @param {Boolean} nsfw
     */
     setNsfw(nsfw) {
-      this.nsfw = nsfw;
+      this.nsfw = Boolean(nsfw);
       return this;
     }
 
@@ -294,7 +308,7 @@ class CommandBuilder {
      * @param {Boolean} slash
     */
     setSlash(slash) {
-      this.slash = slash;
+      this.slash = Boolean(slash);
       return this;
     }
 
@@ -303,7 +317,7 @@ class CommandBuilder {
      * @param {String | Boolean} context
     */
     setContext(context) {
-      this.context = context;
+      this.context = Boolean(context);
       return this;
     }
 

--- a/src/structures/CommandBuilder.js
+++ b/src/structures/CommandBuilder.js
@@ -39,7 +39,7 @@ class CommandBuilder {
 
        /**
          * Args
-         * @type {string}
+         * @type {Array}
         */
        this.args = 'args' in data ? data.args : null;
 

--- a/src/structures/CommandBuilder.js
+++ b/src/structures/CommandBuilder.js
@@ -165,7 +165,7 @@ class CommandBuilder {
 
     /**
      * Method to setArgs
-     * @param {String} usage
+     * @param {Array} args
     */
     setArgs(args) {
       this.args = args;

--- a/src/structures/CommandBuilder.js
+++ b/src/structures/CommandBuilder.js
@@ -170,7 +170,6 @@ class CommandBuilder {
     addArg(arg) {
       if (!Array.isArray(this.args)) this.args = [];
       this.args.push(arg);
-      console.log(this.args);
       return this;
     }
 
@@ -179,9 +178,8 @@ class CommandBuilder {
      * @param {Array<CommandArgsChoice>} args
     */
     addArgs(args) {
-      if (!Array.isArray(this.args)) this.args = [];
       for (const arg of Object.values(args)) {
-        this.args.push(arg);
+        this.addArg(arg);
       }
       return this;
     }

--- a/src/structures/CommandBuilder.js
+++ b/src/structures/CommandBuilder.js
@@ -38,6 +38,12 @@ class CommandBuilder {
        this.usage = 'usage' in data ? resolveString(data.usage) : null;
 
        /**
+         * Args
+         * @type {string}
+        */
+       this.args = 'args' in data ? data.args : null;
+
+       /**
          * Cooldown
          * @type {string}
         */
@@ -127,7 +133,7 @@ class CommandBuilder {
         */
        this.context = 'context' in data ? data.context : null;
 
-       return this;
+       return this.toJSON();
     }
 
     /**
@@ -154,6 +160,15 @@ class CommandBuilder {
     */
     setUsage(usage) {
       this.usage = resolveString(usage);
+      return this;
+    }
+
+    /**
+     * Method to setArgs
+     * @param {String} usage
+    */
+    setArgs(args) {
+      this.args = args;
       return this;
     }
 
@@ -290,6 +305,33 @@ class CommandBuilder {
     setContext(context) {
       this.context = context;
       return this;
+    }
+
+    /**
+     * Method to toJSON
+     * @returns {Object}
+    */
+    toJSON() {
+      return {
+        name: this.name,
+        description: this.description,
+        usage: this.usage,
+        cooldown: this.cooldown,
+        category: this.category,
+        aliases: this.aliases,
+        userRequiredPermissions: this.userRequiredPermissions,
+        userRequiredRoles: this.userRequiredRoles,
+        clientRequiredPermissions: this.clientRequiredPermissions,
+        userOnly: this.userOnly,
+        channelOnly: this.channelOnly,
+        guildOnly: this.guildOnly,
+        channelTextOnly: this.channelTextOnly,
+        channelNewsOnly: this.channelNewsOnly,
+        channelThreadOnly: this.channelThreadOnly,
+        nsfw: this.nsfw,
+        slash: this.slash,
+        context: this.context,
+      };
     }
 }
 

--- a/src/structures/CommandBuilder.js
+++ b/src/structures/CommandBuilder.js
@@ -1,0 +1,296 @@
+const { resolveString } = require('../util/util');
+
+/**
+ * The CommandBuilder class
+ */
+class CommandBuilder {
+    /**
+     * Creates new CommandBuilder instance
+     * @param {Object} data
+    */
+    constructor(data = {}) {
+        this.setup(data);
+    }
+
+    /**
+     * Setup
+     * @param {Object} data
+     * @returns {CommandOptions}
+     * @private
+     */
+    setup(data) {
+       /**
+         * Name
+         * @type {string}
+        */
+       this.name = 'name' in data ? resolveString(data.name) : null;
+
+       /**
+         * Description
+         * @type {string}
+        */
+       this.description = 'description' in data ? resolveString(data.description) : null;
+
+        /**
+         * Usage
+         * @type {string}
+        */
+       this.usage = 'usage' in data ? resolveString(data.usage) : null;
+
+       /**
+         * Cooldown
+         * @type {string}
+        */
+       this.cooldown = 'cooldown' in data ? resolveString(data.cooldown) : null;
+
+       /**
+         * Category
+         * @type {string}
+        */
+       this.category = 'category' in data ? resolveString(data.category) : null;
+
+       /**
+         * Aliases
+         * @type {Array}
+        */
+       this.aliases = 'aliases' in data ? data.aliases : null;
+
+       /**
+         * User
+         * @type {string | Array}
+        */
+       this.userRequiredPermissions = 'userRequiredPermissions' in data ? data.userRequiredPermissions : null;
+
+       /**
+         * UserRequiredRoles
+         * @type {string | Array}
+        */
+       this.userRequiredRoles = 'userRequiredRoles' in data ? data.userRequiredRoles : null;
+
+       /**
+         * ClientRequiredPermissions
+         * @type {string | Array}
+        */
+       this.clientRequiredPermissions = 'clientRequiredPermissions' in data ? data.clientRequiredPermissions : null;
+
+       /**
+         * UserOnly
+         * @type {Snowflake | Array}
+        */
+       this.userOnly = 'userOnly' in data ? data.userOnly : null;
+
+       /**
+         * ChannelOnly
+         * @type {Snowflake | Array}
+        */
+       this.channelOnly = 'channelOnly' in data ? data.channelOnly : null;
+
+       /**
+         * GuildOnly
+         * @type {Snowflake}
+        */
+       this.guildOnly = 'guildOnly' in data ? resolveString(data.guildOnly) : null;
+
+       /**
+         * ChannelTextOnly
+         * @type {Boolean}
+        */
+       this.channelTextOnly = 'channelTextOnly' in data ? Boolean(data.channelTextOnly) : null;
+
+       /**
+         * ChannelNewsOnly
+         * @type {Boolean}
+        */
+       this.channelNewsOnly = 'channelNewsOnly' in data ? Boolean(data.channelNewsOnly) : null;
+
+       /**
+         * ChannelThreadOnly
+         * @type {Boolean}
+        */
+       this.channelThreadOnly = 'channelThreadOnly' in data ? Boolean(data.channelThreadOnly) : null;
+
+       /**
+         * Nsfw
+         * @type {Boolean}
+        */
+       this.nsfw = 'nsfw' in data ? Boolean(data.nsfw) : null;
+
+       /**
+         * Slash
+         * @type {Boolean}
+        */
+       this.slash = 'slash' in data ? Boolean(data.slash) : null;
+
+       /**
+         * Context
+         * @type {string | Boolean}
+        */
+       this.context = 'context' in data ? data.context : null;
+
+       return this;
+    }
+
+    /**
+     * Method to setName
+     * @param {String} name
+    */
+    setName(name) {
+        this.name = resolveString(name);
+        return this;
+    }
+
+    /**
+     * Method to setDescription
+     * @param {String} description
+    */
+    setDescription(description) {
+        this.description = resolveString(description);
+        return this;
+    }
+
+    /**
+     * Method to setUsage
+     * @param {String} usage
+    */
+    setUsage(usage) {
+      this.usage = resolveString(usage);
+      return this;
+    }
+
+    /**
+     * Method to setCooldown
+     * @param {String} cooldown
+    */
+    setCooldown(cooldown) {
+      this.cooldown = resolveString(cooldown);
+      return this;
+    }
+
+    /**
+     * Method to setCategory
+     * @param {String} category
+    */
+    setCategory(category) {
+      this.category = resolveString(category);
+      return this;
+    }
+
+    /**
+     * Method to setAliases
+     * @param {Array} aliases
+    */
+    setAliases(aliases) {
+      this.aliases = aliases;
+      return this;
+    }
+
+    /**
+     * Method to setUserRequiredPermissions
+     * @param {string | Array} permissions
+    */
+    setUserRequiredPermissions(permissions) {
+      this.userRequiredPermissions = permissions;
+      return this;
+    }
+
+    /**
+     * Method to setUserRequiredRoles
+     * @param {string | Array} roles
+    */
+    setUserRequiredRoles(roles) {
+      this.userRequiredRoles = roles;
+      return this;
+    }
+
+    /**
+     * Method to setClientRequiredPermissions
+     * @param {string | Array} permissions
+    */
+    setClientRequiredPermissions(permissions) {
+      this.clientRequiredPermissions = permissions;
+      return this;
+    }
+
+    /**
+     * Method to setUserOnly
+     * @param {Snowflake | Array} userOnly
+    */
+    setUserOnly(userOnly) {
+      this.userOnly = userOnly;
+      return this;
+    }
+
+    /**
+     * Method to setChannelOnly
+     * @param {Snowflake | Array} channelOnly
+    */
+    setChannelOnly(channelOnly) {
+      this.channelOnly = channelOnly;
+      return this;
+    }
+
+    /**
+     * Method to setGuildOnly
+     * @param {Snowflake} guildOnly
+    */
+    setGuildOnly(guildOnly) {
+      this.guildOnly = guildOnly;
+      return this;
+    }
+
+    /**
+     * Method to setChannelTextOnly
+     * @param {Boolean} channelTextOnly
+    */
+    setChannelTextOnly(channelTextOnly) {
+      this.channelTextOnly = channelTextOnly;
+      return this;
+    }
+
+    /**
+     * Method to setChannelNewsOnly
+     * @param {Boolean} channelNewsOnly
+    */
+    setChannelNewsOnly(channelNewsOnly) {
+      this.channelNewsOnly = channelNewsOnly;
+      return this;
+    }
+
+    /**
+     * Method to setChannelThreadOnly
+     * @param {Boolean} channelThreadOnly
+    */
+    setChannelThreadOnly(channelThreadOnly) {
+      this.channelThreadOnly = channelThreadOnly;
+      return this;
+    }
+
+    /**
+     * Method to setNsfw
+     * @param {Boolean} nsfw
+    */
+    setNsfw(nsfw) {
+      this.nsfw = nsfw;
+      return this;
+    }
+
+    /**
+     * Method to setSlash
+     * @param {Boolean} slash
+    */
+    setSlash(slash) {
+      this.slash = slash;
+      return this;
+    }
+
+    /**
+     * Method to setContext
+     * @param {String | Boolean} context
+    */
+    setContext(context) {
+      this.context = context;
+      return this;
+    }
+}
+
+module.exports = CommandBuilder;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -260,6 +260,19 @@ declare module 'gcommands' {
     public setRequired(required: Boolean): CommandArgBuilder;
     public addChoice(choice: CommandArgsChoice): CommandArgBuilder;
     public addChoices(choices: Array<CommandArgsChoice>): CommandArgBuilder;
+    public toJSON(): CommandArgBuilder;
+  }
+
+  export class CommandArgChoiceBuilder {
+    constructor(data: Object);
+    private setup(data: Object);
+
+    public name: String;
+    public value: any;
+
+    public setName(name: String): CommandArgChoiceBuilder;
+    public setValue(value: any): CommandArgChoiceBuilder;
+    public toJSON(): CommandArgChoiceBuilder;
   }
 
   export class MessageActionRow {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -202,7 +202,7 @@ declare module 'gcommands' {
     public name: string;
     public description: string;
     public cooldown: string;
-    public args: Array<object>;
+    public args: Array<CommandArgsOption>;
     public clientRequiredPermissions: String | Array<string>;
     public userRequiredPermissions: String | Array<string>;
     public userRequiredRoles: String | Array<Snowflake>;
@@ -222,7 +222,8 @@ declare module 'gcommands' {
     public setName(name: string): CommandBuilder;
     public setDescription(description: string): CommandBuilder;
     public setCooldown(cooldown: string): CommandBuilder;
-    public setArgs(args: Object): CommandBuilder;
+    public addArg(arg: CommandArgsOption): CommandBuilder;
+    public addArgs(args: Array<CommandArgsOption>): CommandBuilder;
     public setClientRequiredPermissions(permissions: string | Array<string>): CommandBuilder;
     public setUserRequiredPermissions(permissions: string | Array<string>): CommandBuilder;
     public setUserRequiredRoles(permissions: string | Array<Snowflake>): CommandBuilder;
@@ -239,6 +240,26 @@ declare module 'gcommands' {
     public setSlash(slash: GCommandsOptionsCommandsSlash): CommandBuilder;
     public setContext(context: GCommandsOptionsCommandsContext): CommandBuilder;
     public toJSON(): CommandBuilder
+  }
+
+  export class CommandArgBuilder {
+    constructor(data: Object);
+    private setup(data: Object);
+
+    public name: String;
+    public description: String;
+    public type: String;
+    public prompt: String;
+    public required: Boolean;
+    public choices: Array;
+
+    public setName(name: String): CommandArgBuilder;
+    public setDescription(description: String): CommandArgBuilder;
+    public setType(type: String): CommandArgBuilder;
+    public setPrompt(prompt: String): CommandArgBuilder;
+    public setRequired(required: Boolean): CommandArgBuilder;
+    public addChoice(choice: CommandArgsChoice): CommandArgBuilder;
+    public addChoices(choices: Array<CommandArgsChoice>): CommandArgBuilder;
   }
 
   export class MessageActionRow {
@@ -468,7 +489,7 @@ declare module 'gcommands' {
     name: string;
     description: string;
     cooldown?: string;
-    args?: string;
+    args?: Array<Object>;
     userRequiredPermissions?: Array<string> | String;
     userRequiredRoles?: Array<Snowflake> | String;
     clientRequiredPermissions?: Array<string> | String;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -252,6 +252,7 @@ declare module 'gcommands' {
     public prompt: String;
     public required: Boolean;
     public choices: Array;
+    public args: Array<CommandArgsOption>;
 
     public setName(name: String): CommandArgBuilder;
     public setDescription(description: String): CommandArgBuilder;
@@ -260,6 +261,8 @@ declare module 'gcommands' {
     public setRequired(required: Boolean): CommandArgBuilder;
     public addChoice(choice: CommandArgsChoice): CommandArgBuilder;
     public addChoices(choices: Array<CommandArgsChoice>): CommandArgBuilder;
+    public addArg(arg: CommandArgsOption): CommandArgBuilder;
+    public addArgs(args: Array<CommandArgsOption>): CommandArgBuilder;
     public toJSON(): CommandArgBuilder;
   }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -222,6 +222,7 @@ declare module 'gcommands' {
     public setName(name: string): CommandBuilder;
     public setDescription(description: string): CommandBuilder;
     public setCooldown(cooldown: string): CommandBuilder;
+    public setArgs(args: Object): CommandBuilder;
     public setClientRequiredPermissions(permissions: string | Array<string>): CommandBuilder;
     public setUserRequiredPermissions(permissions: string | Array<string>): CommandBuilder;
     public setUserRequiredRoles(permissions: string | Array<Snowflake>): CommandBuilder;
@@ -237,6 +238,7 @@ declare module 'gcommands' {
     public setUsage(usage: string): CommandBuilder;
     public setSlash(slash: GCommandsOptionsCommandsSlash): CommandBuilder;
     public setContext(context: GCommandsOptionsCommandsContext): CommandBuilder;
+    public toJSON(): CommandBuilder
   }
 
   export class MessageActionRow {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -195,6 +195,50 @@ declare module 'gcommands' {
     public get endReason(): string;
   }
 
+  export class CommandBuilder {
+    constructor(data: CommandOptions)
+    private setup(data: CommandOptions)
+
+    public name: string;
+    public description: string;
+    public cooldown: string;
+    public args: Array<object>;
+    public clientRequiredPermissions: String | Array<string>;
+    public userRequiredPermissions: String | Array<string>;
+    public userRequiredRoles: String | Array<Snowflake>;
+    public userOnly: Snowflake | Array<Snowflake>;
+    public channelOnly: Snowflake | Array<Snowflake>;
+    public channelTextOnly: Boolean;
+    public channelNewsOnly: Boolean;
+    public channelThreadOnly: Boolean;
+    public guildOnly: Snowflake | String;
+    public nsfw: boolean;
+    public aliases: Array<string>;
+    public category: string;
+    public usage: string;
+    public slash: GCommandsOptionsCommandsSlash;
+    public context: GCommandsOptionsCommandsContext;
+
+    public setName(name: string): CommandBuilder;
+    public setDescription(description: string): CommandBuilder;
+    public setCooldown(cooldown: string): CommandBuilder;
+    public setClientRequiredPermissions(permissions: string | Array<string>): CommandBuilder;
+    public setUserRequiredPermissions(permissions: string | Array<string>): CommandBuilder;
+    public setUserRequiredRoles(permissions: string | Array<Snowflake>): CommandBuilder;
+    public setUserOnly(userOnly: Snowflake | Array<Snowflake>): CommandBuilder;
+    public setChannelOnly(channelOnly: Snowflake | Array<Snowflake>): CommandBuilder;
+    public setChannelTextOnly(channelTextOnly: Boolean): CommandBuilder;
+    public setChannelNewsOnly(channelNewsOnly: Boolean): CommandBuilder;
+    public setChannelThreadOnly(channelThreadOnly: Boolean): CommandBuilder;
+    public setGuildOnly(guildOnly: Snowflake | string): CommandBuilder;
+    public setNsfw(nsfw: Boolean): CommandBuilder;
+    public setAliases(aliases: Array<string>): CommandBuilder;
+    public setCategory(category: string): CommandBuilder;
+    public setUsage(usage: string): CommandBuilder;
+    public setSlash(slash: GCommandsOptionsCommandsSlash): CommandBuilder;
+    public setContext(context: GCommandsOptionsCommandsContext): CommandBuilder;
+  }
+
   export class MessageActionRow {
     constructor(data: MessageActionRow)
     public type: number;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR adds builders for Commands.

- [x] CommandBuilder
- [x] CommandArgsBuilder
- [x] CommandArgsChoiceBuilder
- [x] Add support for SUB_COMMAND and SUB_COMMAND_GROUP

```javascript
new CommandBuilder()
      .setName('hug')
      .setDescription('Hugs someone!')
      .setCooldown('2s')
      .addArgs([
        new CommandArgBuilder()
          .setName('user')
          .setType(ArgumentType.USER)
          .setDescription('The user to hug!')
          .setPrompt('Who do you want to hug?')
          .setRequired(true)
      ]);
      
      
 // With choices
new CommandBuilder()
      .setName('number')
      .setDescription('number')
      .setCooldown('2s')
      .addArgs([
        new CommandArgBuilder()
          .setName('number')
          .setType(ArgumentType.STRING)
          .setDescription('number')
          .setRequired(true)
          .addChoices([
            new CommandArgChoiceBuilder()
              .setName('1')
              .setValue(1),
            new CommandArgChoiceBuilder()
              .setName('2')
              .setValue(2)
          ])
      ]);
```

Note: the namings are weird because of the conflict with `CommandOptions`. Naming suggestions are welcome!

**Status and versioning classification:**
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
