### PR TITLE
fix(CommandBuilder & CommandArgs): fixed typings & choices

### DIFF
--- a/src/commands/types/integer.js
+++ b/src/commands/types/integer.js
@@ -24,7 +24,7 @@ class IntegerArgumentType extends ArgumentType {
 
 		if (!parseInt(message.content) || (parseInt(message.content) % 1 !== 0)) { return this.client.languageFile.ARGS_MUST_CONTAIN[guildLanguage].replace('{argument}', argument.name).replace('{type}', 'integer'); }
 
-		if (argument.choices && !argument.choices.some(ch => ch.value === message.content.toLowerCase())) { return this.client.languageFile.ARGS_CHOICES[guildLanguage].replace('{choices}', argument.choices.map(opt => `\`${opt.name}\``).join(', ')); }
+		if (argument.choices && !argument.choices.some(ch => ch.name === message.content.toLowerCase())) { return this.client.languageFile.ARGS_CHOICES[guildLanguage].replace('{choices}', argument.choices.map(opt => `\`${opt.name}\``).join(', ')); }
 	}
 }
 

--- a/src/commands/types/number.js
+++ b/src/commands/types/number.js
@@ -24,7 +24,7 @@ class NumberArgumentType extends ArgumentType {
 
 		if (!parseInt(message.content)) { return this.client.languageFile.ARGS_MUST_CONTAIN[guildLanguage].replace('{argument}', argument.name).replace('{type}', 'number'); }
 
-		if (argument.choices && !argument.choices.some(ch => ch.value === message.content.toLowerCase())) { return this.client.languageFile.ARGS_CHOICES[guildLanguage].replace('{choices}', argument.choices.map(opt => `\`${opt.name}\``).join(', ')); }
+		if (argument.choices && !argument.choices.some(ch => ch.name === message.content.toLowerCase())) { return this.client.languageFile.ARGS_CHOICES[guildLanguage].replace('{choices}', argument.choices.map(opt => `\`${opt.name}\``).join(', ')); }
 	}
 }
 

--- a/src/commands/types/string.js
+++ b/src/commands/types/string.js
@@ -21,7 +21,7 @@ class StringArgumentType extends ArgumentType {
 	async validate(argument, message) {
         const guildLanguage = await message.guild.getLanguage();
 
-		if (argument.choices && !argument.choices.some(ch => ch.value === message.content.toLowerCase())) { return this.client.languageFile.ARGS_CHOICES[guildLanguage].replace('{choices}', argument.choices.map(opt => `\`${opt.name}\``).join(', ')); }
+		if (argument.choices && !argument.choices.some(ch => ch.name === message.content.toLowerCase())) { return this.client.languageFile.ARGS_CHOICES[guildLanguage].replace('{choices}', argument.choices.map(opt => `\`${opt.name}\``).join(', ')); }
 	}
 }
 

--- a/src/structures/CommandBuilder.js
+++ b/src/structures/CommandBuilder.js
@@ -165,7 +165,7 @@ class CommandBuilder {
 
     /**
      * Method to addArg
-     * @param {CommandArgsChoice} arg
+     * @param {CommandArgsOption} arg
     */
     addArg(arg) {
       if (!Array.isArray(this.args)) this.args = [];
@@ -175,7 +175,7 @@ class CommandBuilder {
 
     /**
      * Method to addArgs
-     * @param {Array<CommandArgsChoice>} args
+     * @param {Array<CommandArgsOption>} args
     */
     addArgs(args) {
       for (const arg of Object.values(args)) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Fixed a stupid mistake with the typings of the `CommandBuilder` class.

The validation for arguments choices now uses `.name` instead of `.value` to compare.
As the `.name` is the name for the choice, and `.value` should be the returned value.

Example:
```javascript
choice.name = 'True';
choice.value = true;
// If the value is used to compare to the message, it will always return false, because a discord message content is a string
```

**Status and versioning classification:**
- I know how to update typings and have done so, or typings don't need updating