### PR TITLE
fix(Argument): argument returns choice value

### DIFF
--- a/src/commands/argument.js
+++ b/src/commands/argument.js
@@ -100,9 +100,15 @@ class Argument {
             };
         }
 
+        let content = resFirst.content;
+        if (this.choices) {
+            const choice = this.choices.find(ch => ch.name === resFirst.content.toLowerCase());
+            if (choice) content = choice.value;
+        }
+
         return {
             valid: true,
-            content: resFirst.content,
+            content: content,
         };
     }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The `Arguments` class now returns the choice value instead of the message content (if it's a choice). See #147

The `.value` of the choice should be returned, so the name of the choice can be different from its value. (Like discord's slash commands)

Example:
```javascript
choice.name = 'bob';
choice.value = 'user_bob';
```

**Status and versioning classification:**
- I know how to update typings and have done so, or typings don't need updating