### PR TITLE
fix(Typings): fixed typings

### DIFF
--- a/src/base/GCommands.js
+++ b/src/base/GCommands.js
@@ -43,14 +43,14 @@ class GCommands extends EventEmitter {
 
         /**
          * CaseSensitiveCommands
-         * @type {Boolean}
+         * @type {boolean}
          * @default true
         */
         this.caseSensitiveCommands = Boolean(options.caseSensitiveCommands) || true;
 
         /**
          * CaseSensitivePrefixes
-         * @type {Boolean}
+         * @type {boolean}
          * @default true
         */
         this.caseSensitivePrefixes = Boolean(options.caseSensitivePrefixes) || true;
@@ -70,7 +70,7 @@ class GCommands extends EventEmitter {
 
         /**
          * AutoTyping
-         * @type {Boolean}
+         * @type {boolean}
          * @default false
         */
         this.autoTyping = options.autoTyping;
@@ -136,7 +136,7 @@ class GCommands extends EventEmitter {
 
         /**
          * DefaultCooldown
-         * @type {Number}
+         * @type {number}
          * @default 0
          */
         this.defaultCooldown = options.defaultCooldown ? options.defaultCooldown : 0;

--- a/src/base/GCommandsClient.js
+++ b/src/base/GCommandsClient.js
@@ -35,14 +35,14 @@ class GCommandsClient extends Client {
 
         /**
          * CaseSensitiveCommands
-         * @type {Boolean}
+         * @type {boolean}
          * @default true
         */
         this.caseSensitiveCommands = options.caseSensitiveCommands ? Boolean(options.caseSensitiveCommands) : true;
 
         /**
          * CaseSensitivePrefixes
-         * @type {Boolean}
+         * @type {boolean}
          * @default true
         */
         this.caseSensitivePrefixes = options.caseSensitivePrefixes ? Boolean(options.caseSensitivePrefixes) : true;
@@ -62,7 +62,7 @@ class GCommandsClient extends Client {
 
         /**
          * AutoTyping
-         * @type {Boolean}
+         * @type {boolean}
          * @default false
         */
         this.autoTyping = options.autoTyping;
@@ -128,7 +128,7 @@ class GCommandsClient extends Client {
 
         /**
          * DefaultCooldown
-         * @type {Number}
+         * @type {number}
          * @default 0
          */
         this.defaultCooldown = options.defaultCooldown ? options.defaultCooldown : 0;

--- a/src/base/GCommandsDispatcher.js
+++ b/src/base/GCommandsDispatcher.js
@@ -80,7 +80,7 @@ class GCommandsDispatcher {
     /**
      * Internal method to getGuildPrefix
      * @param {Snowflake} guildId
-     * @param {Boolean} cache
+     * @param {boolean} cache
      * @returns {string}
     */
     async getGuildPrefix(guildId, cache = true) {
@@ -105,7 +105,7 @@ class GCommandsDispatcher {
      * @param {Snowflake} guildId
      * @param {Snowflake} userId
      * @param {Command} command
-     * @returns {String}
+     * @returns {string}
     */
     async getCooldown(guildId, userId, command) {
         if (this.application && this.application.owners.some(user => user.id === userId)) return { cooldown: false };
@@ -199,7 +199,7 @@ class GCommandsDispatcher {
     /**
      * Internal method to getGuildLanguage
      * @param {Snowflake} guildId
-     * @param {Boolean} cache
+     * @param {boolean} cache
      * @returns {boolean}
     */
     async getGuildLanguage(guildId, cache = true) {

--- a/src/commands/argument.js
+++ b/src/commands/argument.js
@@ -67,7 +67,7 @@ class Argument {
     /**
      * Method to obtain
      * @param {Message|Object}
-     * @param {String}
+     * @param {string}
      */
     async obtain(message, prompt = this.prompt) {
         if (message.author.bot) return;

--- a/src/commands/base.js
+++ b/src/commands/base.js
@@ -37,7 +37,7 @@ class Command {
 
         /**
          * ExpectedArgs
-         * @type {String | Array}
+         * @type {string | Array}
          * @deprecated
          */
         this.expectedArgs = options.expectedArgs;
@@ -50,26 +50,26 @@ class Command {
 
         /**
          * MinArgs
-         * @type {Number}
+         * @type {number}
          * @deprecated use args
          */
         this.minArgs = Number(options.minArgs);
 
         /**
          * UserRequiredPermissions
-         * @type {String | Array}
+         * @type {string | Array}
          */
         this.userRequiredPermissions = options.userRequiredPermissions;
 
         /**
          * UserRequiredRoles
-         * @type {String | Array}
+         * @type {string | Array}
          */
         this.userRequiredRoles = options.userRequiredRoles;
 
         /**
          * ClientRequiredPermissions
-         * @type {String | Array}
+         * @type {string | Array}
          */
         this.clientRequiredPermissions = options.clientRequiredPermissions;
 
@@ -87,19 +87,19 @@ class Command {
 
         /**
          * ChannelTextOnly
-         * @type {Boolean}
+         * @type {boolean}
          */
         this.channelTextOnly = options.channelTextOnly;
 
         /**
          * ChannelNewsOnly
-         * @type {Boolean}
+         * @type {boolean}
          */
         this.channelNewsOnly = options.channelNewsOnly;
 
         /**
          * ChannelThreadOnly
-         * @type {Boolean}
+         * @type {boolean}
          */
         this.channelThreadOnly = options.channelThreadOnly;
 
@@ -111,13 +111,13 @@ class Command {
 
         /**
          * Nsfw
-         * @type {Boolean}
+         * @type {boolean}
          */
         this.nsfw = options.nsfw;
 
         /**
          * Slash
-         * @type {Boolean}
+         * @type {boolean}
          */
         this.slash = options.slash;
 

--- a/src/commands/types/base.js
+++ b/src/commands/types/base.js
@@ -7,7 +7,7 @@ class ArgumentType {
     /**
      * The ArgumentType class
      * @param {Client}
-     * @param {String} type
+     * @param {string} type
      */
     constructor(client, type) {
         if (!client) throw new GError('[ARGUMENTS]','You must specify the client');

--- a/src/structures/CommandArgsChoiceBuilder.js
+++ b/src/structures/CommandArgsChoiceBuilder.js
@@ -36,7 +36,7 @@ class CommandArgsChoiceBuilder {
 
     /**
      * Method to setName
-     * @param {String} name
+     * @param {string} name
     */
     setName(name) {
         this.name = resolveString(name);

--- a/src/structures/CommandArgsOptionBuilder.js
+++ b/src/structures/CommandArgsOptionBuilder.js
@@ -33,7 +33,7 @@ class CommandArgsOptionBuilder {
 
         /**
          * Type
-         * @type {Number}
+         * @type {number}
         */
         this.type = 'type' in data ? Number(data.type) : null;
 
@@ -45,7 +45,7 @@ class CommandArgsOptionBuilder {
 
         /**
          * Required
-         * @type {Boolean}
+         * @type {boolean}
         */
         this.required = 'required' in data ? Boolean(data.required) : null;
 
@@ -66,7 +66,7 @@ class CommandArgsOptionBuilder {
 
     /**
      * Method to setName
-     * @param {String} name
+     * @param {string} name
     */
     setName(name) {
         this.name = resolveString(name);
@@ -75,7 +75,7 @@ class CommandArgsOptionBuilder {
 
     /**
      * Method to setDescription
-     * @param {String} description
+     * @param {string} description
     */
     setDescription(description) {
         this.description = resolveString(description);
@@ -84,7 +84,7 @@ class CommandArgsOptionBuilder {
 
     /**
      * Method to setType
-     * @param {String} type
+     * @param {string} type
     */
     setType(type) {
         this.type = Number(type);
@@ -93,7 +93,7 @@ class CommandArgsOptionBuilder {
 
     /**
      * Method to setPrompt
-     * @param {String} prompt
+     * @param {string} prompt
     */
     setPrompt(prompt) {
         this.prompt = resolveString(prompt);
@@ -102,7 +102,7 @@ class CommandArgsOptionBuilder {
 
     /**
      * Method to setRequired
-     * @param {Boolean} required
+     * @param {boolean} required
     */
     setRequired(required) {
         this.required = Boolean(required);

--- a/src/structures/CommandOptionsBuilder.js
+++ b/src/structures/CommandOptionsBuilder.js
@@ -99,37 +99,37 @@ class CommandOptionsBuilder {
 
        /**
          * ChannelTextOnly
-         * @type {Boolean}
+         * @type {boolean}
         */
        this.channelTextOnly = 'channelTextOnly' in data ? Boolean(data.channelTextOnly) : null;
 
        /**
          * ChannelNewsOnly
-         * @type {Boolean}
+         * @type {boolean}
         */
        this.channelNewsOnly = 'channelNewsOnly' in data ? Boolean(data.channelNewsOnly) : null;
 
        /**
          * ChannelThreadOnly
-         * @type {Boolean}
+         * @type {boolean}
         */
        this.channelThreadOnly = 'channelThreadOnly' in data ? Boolean(data.channelThreadOnly) : null;
 
        /**
          * Nsfw
-         * @type {Boolean}
+         * @type {boolean}
         */
        this.nsfw = 'nsfw' in data ? Boolean(data.nsfw) : null;
 
        /**
          * Slash
-         * @type {Boolean}
+         * @type {boolean}
         */
        this.slash = 'slash' in data ? Boolean(data.slash) : null;
 
        /**
          * Context
-         * @type {string | Boolean}
+         * @type {string | boolean}
         */
        this.context = 'context' in data ? data.context : null;
 
@@ -138,7 +138,7 @@ class CommandOptionsBuilder {
 
     /**
      * Method to setName
-     * @param {String} name
+     * @param {string} name
     */
     setName(name) {
         this.name = resolveString(name);
@@ -147,7 +147,7 @@ class CommandOptionsBuilder {
 
     /**
      * Method to setDescription
-     * @param {String} description
+     * @param {string} description
     */
     setDescription(description) {
         this.description = resolveString(description);
@@ -156,7 +156,7 @@ class CommandOptionsBuilder {
 
     /**
      * Method to setUsage
-     * @param {String} usage
+     * @param {string} usage
     */
     setUsage(usage) {
       this.usage = resolveString(usage);
@@ -186,7 +186,7 @@ class CommandOptionsBuilder {
 
     /**
      * Method to setCooldown
-     * @param {String} cooldown
+     * @param {string} cooldown
     */
     setCooldown(cooldown) {
       this.cooldown = resolveString(cooldown);
@@ -195,7 +195,7 @@ class CommandOptionsBuilder {
 
     /**
      * Method to setCategory
-     * @param {String} category
+     * @param {string} category
     */
     setCategory(category) {
       this.category = resolveString(category);
@@ -267,7 +267,7 @@ class CommandOptionsBuilder {
 
     /**
      * Method to setChannelTextOnly
-     * @param {Boolean} channelTextOnly
+     * @param {boolean} channelTextOnly
     */
     setChannelTextOnly(channelTextOnly) {
       this.channelTextOnly = Boolean(channelTextOnly);
@@ -276,7 +276,7 @@ class CommandOptionsBuilder {
 
     /**
      * Method to setChannelNewsOnly
-     * @param {Boolean} channelNewsOnly
+     * @param {boolean} channelNewsOnly
     */
     setChannelNewsOnly(channelNewsOnly) {
       this.channelNewsOnly = Boolean(channelNewsOnly);
@@ -285,7 +285,7 @@ class CommandOptionsBuilder {
 
     /**
      * Method to setChannelThreadOnly
-     * @param {Boolean} channelThreadOnly
+     * @param {boolean} channelThreadOnly
     */
     setChannelThreadOnly(channelThreadOnly) {
       this.channelThreadOnly = Boolean(channelThreadOnly);
@@ -294,7 +294,7 @@ class CommandOptionsBuilder {
 
     /**
      * Method to setNsfw
-     * @param {Boolean} nsfw
+     * @param {boolean} nsfw
     */
     setNsfw(nsfw) {
       this.nsfw = Boolean(nsfw);
@@ -303,7 +303,7 @@ class CommandOptionsBuilder {
 
     /**
      * Method to setSlash
-     * @param {Boolean} slash
+     * @param {boolean} slash
     */
     setSlash(slash) {
       this.slash = Boolean(slash);
@@ -312,7 +312,7 @@ class CommandOptionsBuilder {
 
     /**
      * Method to setContext
-     * @param {String | Boolean} context
+     * @param {string | boolean} context
     */
     setContext(context) {
       this.context = Boolean(context);

--- a/src/structures/Event.js
+++ b/src/structures/Event.js
@@ -14,20 +14,20 @@ Event.name = GEvents.Event.name;
 
 /**
  * Once
- * @type {Boolean}
+ * @type {boolean}
  */
 Event.once = GEvents.Event.once;
 
 /**
  * Ws
- * @type {Boolean}
+ * @type {boolean}
  */
 Event.ws = GEvents.Event.ws;
 
 /**
  * Run function
  * @param {Client}
- * @param {String}
+ * @param {string}
  */
 Event.run = () => GEvents.Event.run;
 

--- a/src/structures/EventOptionsBuilder.js
+++ b/src/structures/EventOptionsBuilder.js
@@ -26,7 +26,7 @@ EventOptionsBuilder.ws = GEvents.EventOptionsBuilder.ws;
 
 /**
  * Method to setName
- * @param {String} name
+ * @param {string} name
 */
 EventOptionsBuilder.setName = () => GEvents.EventOptionsBuilder.setName;
 

--- a/src/structures/GGuild.js
+++ b/src/structures/GGuild.js
@@ -38,7 +38,7 @@ const { Guild } = require('discord.js');
     /* eslint-disable no-empty-function */
     /**
      * Method to getCommandPrefix
-     * @param {Boolean} cache
+     * @param {boolean} cache
      * @returns {Promise}
     */
     getCommandPrefix() {}
@@ -52,7 +52,7 @@ const { Guild } = require('discord.js');
 
     /**
      * Method to getLanguage
-     * @param {Boolean} cache
+     * @param {boolean} cache
      * @returns {Promise}
     */
     getLanguage() {}

--- a/src/structures/GInteraction.js
+++ b/src/structures/GInteraction.js
@@ -167,7 +167,7 @@ class GInteraction {
 
     /**
      * Method to defer
-     * @param {Boolean} ephemeral
+     * @param {boolean} ephemeral
     */
     async defer(ephemeral) {
         if (this._replied) throw new GError('[ALREADY REPLY]','This interaction already has a reply');
@@ -188,7 +188,7 @@ class GInteraction {
 
     /**
      * Method to think
-     * @param {Boolean} ephemeral
+     * @param {boolean} ephemeral
     */
     async think(ephemeral) {
         if (this._replied) throw new GError('[ALREADY REPLY]','This interaction already has a reply');

--- a/src/structures/MessageActionRow.js
+++ b/src/structures/MessageActionRow.js
@@ -57,8 +57,8 @@ class MessageActionRow extends BaseMessageComponent {
 
     /**
      * Method to removeComponents
-     * @param {Number} index
-     * @param {Number} deleteCount
+     * @param {number} index
+     * @param {number} deleteCount
      * @param {MessageButton[] | MessageSelectMenu[]} components
     */
     removeComponents(index, deleteCount, ...components) {

--- a/src/structures/MessageButton.js
+++ b/src/structures/MessageButton.js
@@ -53,7 +53,7 @@ class MessageButton extends BaseMessageComponent {
 
         /**
          * Disabled
-         * @type {Boolean}
+         * @type {boolean}
         */
         this.disabled = 'disabled' in data ? Boolean(data.disabled) : false;
 
@@ -76,7 +76,7 @@ class MessageButton extends BaseMessageComponent {
 
     /**
      * Method to setStyle
-     * @param {String} style
+     * @param {string} style
     */
     setStyle(style) {
         this.style = this.resolveStyle(resolveString(style.toLowerCase()));
@@ -85,7 +85,7 @@ class MessageButton extends BaseMessageComponent {
 
     /**
      * Method to setLabel
-     * @param {String} label
+     * @param {string} label
     */
     setLabel(label) {
         this.label = resolveString(label);
@@ -94,7 +94,7 @@ class MessageButton extends BaseMessageComponent {
 
     /**
      * Method to setEmoji
-     * @param {String} emoji
+     * @param {string} emoji
     */
     setEmoji(emoji) {
         this.emoji = parseEmoji(`${emoji}`);
@@ -103,7 +103,7 @@ class MessageButton extends BaseMessageComponent {
 
     /**
      * Method to setDisabled
-     * @param {String} boolean
+     * @param {string} boolean
     */
     setDisabled(boolean = true) {
         this.disabled = Boolean(boolean);
@@ -112,7 +112,7 @@ class MessageButton extends BaseMessageComponent {
 
     /**
      * Method to setURL
-     * @param {String} url
+     * @param {string} url
     */
     setURL(url) {
         this.url = resolveString(url);

--- a/src/structures/MessageComponentInteraction.js
+++ b/src/structures/MessageComponentInteraction.js
@@ -17,13 +17,13 @@ class MessageComponentInteraction extends GInteraction {
 
         /**
          * The component's type
-         * @type {Number}
+         * @type {number}
          */
         this.componentType = MessageComponentTypes[data.data.component_type];
 
         /**
          * The component's customId
-         * @type {Number}
+         * @type {number}
          */
         this.customId = data.data.custom_id;
 

--- a/src/structures/MessageSelectMenu.js
+++ b/src/structures/MessageSelectMenu.js
@@ -59,7 +59,7 @@ class MessageSelectMenu extends BaseMessageComponent {
 
         /**
          * Disabled
-         * @type {Boolean}
+         * @type {boolean}
         */
         this.disabled = 'disabled' in data ? Boolean(data.disabled) : false;
 
@@ -68,7 +68,7 @@ class MessageSelectMenu extends BaseMessageComponent {
 
     /**
      * Method to setDisabled
-     * @param {String} boolean
+     * @param {string} boolean
     */
     setPlaceholder(string) {
         this.placeholder = resolveString(string);
@@ -77,7 +77,7 @@ class MessageSelectMenu extends BaseMessageComponent {
 
     /**
      * Method to setMaxValues
-     * @param {Number} int
+     * @param {number} int
     */
     setMaxValues(int = 1) {
         this.max_values = Number(int);
@@ -86,7 +86,7 @@ class MessageSelectMenu extends BaseMessageComponent {
 
     /**
      * Method to setMinValues
-     * @param {Number} int
+     * @param {number} int
     */
     setMinValues(int = 1) {
         this.min_values = Number(int);
@@ -95,7 +95,7 @@ class MessageSelectMenu extends BaseMessageComponent {
 
     /**
      * Method to setID
-     * @param {String} id
+     * @param {string} id
      * @deprecated
     */
     setID(id) {
@@ -114,7 +114,7 @@ class MessageSelectMenu extends BaseMessageComponent {
 
     /**
      * Method to setDisabled
-     * @param {String} boolean
+     * @param {string} boolean
     */
     setDisabled(boolean = true) {
         this.disabled = Boolean(boolean);
@@ -143,8 +143,8 @@ class MessageSelectMenu extends BaseMessageComponent {
 
     /**
      * Method to removeOptions
-     * @param {Number} index
-     * @param {Number} deleteCount
+     * @param {number} index
+     * @param {number} deleteCount
      * @param {MessageSelectMenuOption[]} MessageSelectMenuOption[]
     */
     removeOptions(index, deleteCount, ...options) {

--- a/src/structures/MessageSelectMenuOption.js
+++ b/src/structures/MessageSelectMenuOption.js
@@ -45,7 +45,7 @@ class MessageSelectMenuOption {
 
         /**
          * Default
-         * @type {Boolean}
+         * @type {boolean}
         */
         this.default = 'default' in data ? Boolean(data.default) : false;
 
@@ -54,7 +54,7 @@ class MessageSelectMenuOption {
 
     /**
      * Method to setLabel
-     * @param {String} label
+     * @param {string} label
     */
     setLabel(label) {
         this.label = resolveString(label);
@@ -63,7 +63,7 @@ class MessageSelectMenuOption {
 
     /**
      * Method to setValue
-     * @param {String} value
+     * @param {string} value
     */
     setValue(value) {
         this.value = resolveString(value);
@@ -72,7 +72,7 @@ class MessageSelectMenuOption {
 
     /**
      * Method to setValue
-     * @param {String} desc
+     * @param {string} desc
     */
     setDescription(desc) {
         this.description = resolveString(desc);
@@ -81,7 +81,7 @@ class MessageSelectMenuOption {
 
     /**
      * Method to setEmoji
-     * @param {String} emoji
+     * @param {string} emoji
     */
     setEmoji(emoji) {
         this.emoji = parseEmoji(`${emoji}`);
@@ -90,7 +90,7 @@ class MessageSelectMenuOption {
 
     /**
      * Method to setDefault
-     * @param {Boolean} default
+     * @param {boolean} default
     */
     setDefault(def = true) {
         this.default = Boolean(def);

--- a/src/structures/v12/ButtonCollector.js
+++ b/src/structures/v12/ButtonCollector.js
@@ -26,7 +26,7 @@ class ButtonCollector extends Collector {
 
     /**
      * Total
-     * @type {Number}
+     * @type {number}
      */
     this.total = 0;
 

--- a/src/structures/v12/InteractionCollector.js
+++ b/src/structures/v12/InteractionCollector.js
@@ -61,7 +61,7 @@ class InteractionCollector extends Collector {
 
     /**
      * Total
-     * @type {Number}
+     * @type {number}
      */
     this.total = 0;
 

--- a/src/structures/v12/SelectMenuCollector.js
+++ b/src/structures/v12/SelectMenuCollector.js
@@ -26,7 +26,7 @@ const { Events } = require('discord.js').Constants;
 
     /**
      * Total
-     * @type {Number}
+     * @type {number}
      */
     this.total = 0;
 

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -185,9 +185,9 @@ function createEnum(keys) {
  * @property {MessageEmbed[]} embeds
  * @property {MessageActionRow[]} components
  * @property {MessageAttachment[]} attachments
- * @property {Boolean} ephemeral
+ * @property {boolean} ephemeral
  * @property {Object} allowedMentions
- * @property {(string | Boolean)} inlineReply
+ * @property {(string | boolean)} inlineReply
  * @property {(string | Array)} stickers
  * @example .send({
  *  content: 'hello',

--- a/src/util/util.js
+++ b/src/util/util.js
@@ -7,8 +7,8 @@ const { InteractionTypes, MessageComponentTypes } = require('./Constants');
 class Util {
     /**
      * Internal method to resolveString
-     * @param {String | Array} data
-     * @returns {String}
+     * @param {string | Array} data
+     * @returns {string}
     */
     static resolveString(data) {
         if (typeof data === 'string') return data;
@@ -18,7 +18,7 @@ class Util {
 
     /**
      * Internal method to msToSeconds
-     * @param {Number} ms
+     * @param {number} ms
      * @returns {number}
     */
     static msToSeconds(ms) {
@@ -28,7 +28,7 @@ class Util {
 
     /**
      * Internal method to parseEmoji
-     * @param {String} text
+     * @param {string} text
      * @returns {Object}
     */
     static parseEmoji(text) {
@@ -119,7 +119,7 @@ class Util {
     /**
      * Internal method to deleteCmd
      * @param {Client} client
-     * @param {Number} commandId
+     * @param {number} commandId
      * @private
     */
     static async __deleteCmd(client, commandId, guildId = undefined) {
@@ -138,7 +138,7 @@ class Util {
     /**
      * Internal method to getAllCommands
      * @param {Client} client
-     * @param {Number} guildId
+     * @param {number} guildId
      * @private
     */
     static async __getAllCommands(client, guildId = undefined) {
@@ -166,8 +166,8 @@ class Util {
 
     /**
      * Internal method to checkDjsVersion
-     * @param {Number} needVer
-     * @returns {Boolean}
+     * @param {number} needVer
+     * @returns {boolean}
      * @private
     */
     static checkDjsVersion(needVer) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Fixed wrong typings:
`String -> string`
`Number -> number`
`Boolean -> boolean`

This is so the docs correctly generate the corresponding links.

(Thanks to VS Code Search)

**Status and versioning classification:**
- I know how to update typings and have done so, or typings don't need updating
