### PR TITLE
Fix GCommandLoader.js __loadCommandFiles to support filenames with multiple dots

### DIFF
--- a/src/managers/GCommandLoader.js
+++ b/src/managers/GCommandLoader.js
@@ -49,8 +49,9 @@ class GCommandLoader {
      */
     async __loadCommandFiles() {
         for await (let file of (await fs.readdirSync(this.cmdDir))) {
-            const fileName = file.split('.').reverse()[1] || file;
-            const fileType = file.split('.').reverse()[0];
+            const fileTypeIndex = (file.lastIndexOf(".") - 1 >>> 0) + 2;
+            const fileName = file.slice(0, fileTypeIndex - 1);
+            const fileType = file.slice(fileTypeIndex);
 
             if (!['js', 'ts'].includes(fileType)) {
                 await this.__loadCommandCategoryFiles(file);

--- a/src/managers/GCommandLoader.js
+++ b/src/managers/GCommandLoader.js
@@ -49,7 +49,7 @@ class GCommandLoader {
      */
     async __loadCommandFiles() {
         for await (let file of (await fs.readdirSync(this.cmdDir))) {
-            const fileTypeIndex = (file.lastIndexOf(".") - 1 >>> 0) + 2;
+            const fileTypeIndex = (file.lastIndexOf('.') - 1 >>> 0) + 2;
             const fileName = file.slice(0, fileTypeIndex - 1);
             const fileType = file.slice(fileTypeIndex);
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

- Using split('.') will unintentionally create more splits with filenames that contain more than one period, breaking __loadCommandFiles
- Small three line fix that will properly extract the extension from the filename

Before - [jsfiddle](https://jsfiddle.net/yq9pa5w3/13/)
```javascript
const file = "test.js.map"

const fileName = file.split('.').reverse()[1] || file;  // "js"
const fileType = file.split('.').reverse()[0]; // "map"

console.log(fileName); // "js"
console.log(fileType); // "map"
```

After - [jsfiddle](https://jsfiddle.net/yq9pa5w3/16/)
```javascript
const file = "test.js.map"

const fileTypeIndex = (file.lastIndexOf(".") - 1 >>> 0) + 2;
const fileName = file.slice(0, fileTypeIndex - 1); // "test.js"
const fileType = file.slice(fileTypeIndex); // "map"

console.log(fileName); // "test.js"
console.log(fileType); // "map"
```

Files only ending in `js`, `ts`, or custom included types should now be matched, regardless of how many dots are in the filename.

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- I know how to update typings and have done so, or typings don't need updating
-->