### PR TITLE
fix(context & slash): fix for context and slash command options

### DIFF
--- a/src/managers/GCommandLoader.js
+++ b/src/managers/GCommandLoader.js
@@ -1,4 +1,4 @@
-const Color = require('../structures/Color'), GError = require('../structures/GError'), { Events, ApplicationCommandTypesRaw, ArgumentType } = require('../util/Constants');
+const Color = require('../structures/Color'), GError = require('../structures/GError'), { Events, ApplicationCommandTypesRaw } = require('../util/Constants');
 const axios = require('axios');
 const fs = require('fs');
 const ms = require('ms');
@@ -129,23 +129,6 @@ class GCommandLoader {
                 continue;
             }
 
-            const args = cmd.args ? JSON.parse(JSON.stringify(cmd.args)) : [];
-
-            for (const arg of args) {
-                if (arg.args) {
-                    if (arg.type === ArgumentType.SUB_COMMAND_GROUP) {
-                        for (const subArg of arg.args) {
-                            if (subArg.args) {
-                                subArg.options = subArg.args;
-                                delete subArg.args;
-                            }
-                        }
-                    }
-                    arg.options = arg.args;
-                    delete arg.args;
-                }
-            }
-
             let config = {
                 method: 'POST',
                 headers: {
@@ -155,7 +138,7 @@ class GCommandLoader {
                 data: JSON.stringify({
                     name: cmd.name,
                     description: cmd.description,
-                    options: args,
+                    options: cmd.args,
                     type: 1,
                     default_permission: (Object.values(cmd)[8] || Object.values(cmd)[10]) === undefined,
                 }),

--- a/src/managers/GEventHandling.js
+++ b/src/managers/GEventHandling.js
@@ -37,8 +37,6 @@ class GEventHandling {
      * @private
     */
     messageEvent() {
-        if (String(this.client.slash) === 'true') return;
-
         this.client.on(ifDjsV13 ? 'messageCreate' : 'message', message => {
             messageEventUse(message);
         });
@@ -64,7 +62,8 @@ class GEventHandling {
                 commandos = this.client.gcommands.get(this.GCommandsClient.caseSensitiveCommands ? cmd.toLowerCase() : cmd);
                 if (!commandos) commandos = this.client.gcommands.get(this.client.galiases.get(this.GCommandsClient.caseSensitiveCommands ? cmd.toLowerCase() : cmd));
 
-                if (!commandos || String(commandos.slash) === 'true') return;
+                if (!commandos || ['false', 'slash'].includes(String(commandos.slash))) return;
+                if (!commandos.slash && ['false', 'slash'].includes(String(this.client.slash))) return;
 
                 let member = message.member, guild = message.guild, channel = message.channel;
                 let botMessageInhibit;
@@ -120,7 +119,7 @@ class GEventHandling {
                     if (!Array.isArray(commandos.clientRequiredPermissions)) commandos.clientRequiredPermissions = [commandos.clientRequiredPermissions];
 
                     if (message.channel.permissionsFor(message.guild.me).missing(commandos.clientRequiredPermissions).length > 0) {
-                        let permsNeed = this.client.languageFile.MISSING_CLIENT_PERMISSIONS[guildLanguage].replace('{PERMISSION}',commandos.clientRequiredPermissions.map(v => unescape(v, '_')).join(', '));
+                        let permsNeed = this.client.languageFile.MISSING_CLIENT_PERMISSIONS[guildLanguage].replace('{PERMISSION}', commandos.clientRequiredPermissions.map(v => unescape(v, '_')).join(', '));
                         return message.reply(permsNeed);
                     }
                 }
@@ -129,7 +128,7 @@ class GEventHandling {
                     if (!Array.isArray(commandos.userRequiredPermissions)) commandos.userRequiredPermissions = [commandos.userRequiredPermissions];
 
                     if (!member.permissions.has(commandos.userRequiredPermissions)) {
-                        let permsNeed = this.client.languageFile.MISSING_PERMISSIONS[guildLanguage].replace('{PERMISSION}',commandos.userRequiredPermissions.map(v => unescape(v, '_')).join(', '));
+                        let permsNeed = this.client.languageFile.MISSING_PERMISSIONS[guildLanguage].replace('{PERMISSION}', commandos.userRequiredPermissions.map(v => unescape(v, '_')).join(', '));
                         return message.reply(permsNeed);
                     }
                 }
@@ -319,13 +318,8 @@ class GEventHandling {
      * @private
     */
     slashEvent() {
-        if (String(this.client.slash) === 'false') return;
-
         this.client.on('GInteraction', async interaction => {
             if (!interaction.isApplication()) return;
-
-            if (interaction.isCommand() && String(this.client.slash) === 'false') return;
-            if (interaction.isContextMenu() && String(this.client.context) === 'false') return;
 
             if (!interaction.guild) return;
 
@@ -333,8 +327,10 @@ class GEventHandling {
             try {
                 commandos = this.client.gcommands.get(this.GCommandsClient.caseSensitiveCommands ? interaction.commandName.toLowerCase() : interaction.commandName);
                 if (!commandos) return;
-                if (interaction.isCommand() && String(commandos.slash) === 'false') return;
+                if (interaction.isCommand() && ['false', 'message'].includes(String(commandos.slash))) return;
+                if (interaction.isCommand() && !commandos.slash && ['false', 'message'].includes(String(this.client.slash))) return;
                 if (interaction.isContextMenu() && String(commandos.context) === 'false') return;
+                if (interaction.isContextMenu() && !commandos.context && String(this.client.context) === 'false') return;
 
                 let inhibitReturn = await inhibit(this.client, interactionRefactor(interaction, commandos), {
                     interaction,
@@ -380,8 +376,9 @@ class GEventHandling {
                     if (!Array.isArray(commandos.clientRequiredPermissions)) commandos.clientRequiredPermissions = [commandos.clientRequiredPermissions];
 
                     if (interaction.guild.channels.cache.get(interaction.channel.id).permissionsFor(interaction.guild.me).missing(commandos.clientRequiredPermissions).length > 0) {
-                        return interaction.reply.send({ content:
-                            this.client.languageFile.MISSING_CLIENT_PERMISSIONS[guildLanguage].replace('{PERMISSION}',commandos.clientRequiredPermissions.map(v => unescape(v, '_')).join(', ')), ephemeral: true,
+                        return interaction.reply.send({
+                            content:
+                                this.client.languageFile.MISSING_CLIENT_PERMISSIONS[guildLanguage].replace('{PERMISSION}', commandos.clientRequiredPermissions.map(v => unescape(v, '_')).join(', ')), ephemeral: true,
                         });
                     }
                 }
@@ -390,8 +387,9 @@ class GEventHandling {
                     if (!Array.isArray(commandos.userRequiredPermissions)) commandos.userRequiredPermissions = [commandos.userRequiredPermissions];
 
                     if (!interaction.member.permissions.has(commandos.userRequiredPermissions)) {
-                        return interaction.reply.send({ content:
-                            this.client.languageFile.MISSING_PERMISSIONS[guildLanguage].replace('{PERMISSION}',commandos.userRequiredPermissions.map(v => unescape(v, '_')).join(', ')), ephemeral: true,
+                        return interaction.reply.send({
+                            content:
+                                this.client.languageFile.MISSING_PERMISSIONS[guildLanguage].replace('{PERMISSION}', commandos.userRequiredPermissions.map(v => unescape(v, '_')).join(', ')), ephemeral: true,
                         });
                     }
                 }

--- a/src/structures/CommandArgsOptionBuilder.js
+++ b/src/structures/CommandArgsOptionBuilder.js
@@ -56,10 +56,10 @@ class CommandArgsOptionBuilder {
         this.choices = 'choices' in data ? data.choises : null;
 
         /**
-         * Args
+         * Options
          * @type {Array<CommandArgsOption>}
         */
-         this.args = 'args' in data ? data.args : null;
+         this.options = 'options' in data ? data.options : null;
 
         return this.toJSON();
     }
@@ -131,22 +131,22 @@ class CommandArgsOptionBuilder {
     }
 
     /**
-     * Method to addArg
-     * @param {CommandArgsOption} arg
+     * Method to addOption
+     * @param {CommandArgsOption} option
     */
-     addArg(arg) {
-        if (!Array.isArray(this.args)) this.args = [];
-        this.args.push(arg);
+     addOption(option) {
+        if (!Array.isArray(this.options)) this.options = [];
+        this.options.push(option);
         return this;
       }
 
       /**
-       * Method to addArgs
-       * @param {Array<CommandArgsOption>} args
+       * Method to addOptions
+       * @param {Array<CommandArgsOption>} options
       */
-      addArgs(args) {
-        for (const arg of Object.values(args)) {
-          this.addArg(arg);
+      addArgs(options) {
+        for (const option of Object.values(options)) {
+          this.addOption(option);
         }
         return this;
       }
@@ -163,6 +163,7 @@ class CommandArgsOptionBuilder {
           prompt: this.prompt,
           required: this.required,
           choises: this.choices,
+          options: this.options,
         };
       }
 }

--- a/src/structures/CommandArgsOptionBuilder.js
+++ b/src/structures/CommandArgsOptionBuilder.js
@@ -144,7 +144,7 @@ class CommandArgsOptionBuilder {
        * Method to addOptions
        * @param {Array<CommandArgsOption>} options
       */
-      addArgs(options) {
+      addOptions(options) {
         for (const option of Object.values(options)) {
           this.addOption(option);
         }

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -194,7 +194,8 @@ function createEnum(keys) {
 /**
  * The GCommandsOptionsCommandsSlash
  * * both
- * * true
+ * * slash
+ * * message
  * * false
  * @typedef {(string | boolean)} GCommandsOptionsCommandsSlash
  */
@@ -243,7 +244,6 @@ function createEnum(keys) {
  * @property {GPayloadOptions} edit
  * @property {Array} args
  * @property {Object} objectArgs
- * @property {Array<string>} subcommands
  * @typedef {(Object)} CommandRunOptions
 */
 
@@ -292,7 +292,7 @@ function createEnum(keys) {
  * @property {boolean} channelNewsOnly
  * @property {boolean} channelThreadOnly
  * @property {boolean} nsfw
- * @property {boolean} slash
+ * @property {GCommandsOptionsCommandsSlash} slash
  * @property {GCommandsOptionsCommandsContext} context
  * @typedef {(Object)} CommandOptions
  */
@@ -306,7 +306,7 @@ function createEnum(keys) {
  * @property {string} prompt
  * @property {boolean} required
  * @property {CommandArgsChoice[]} choices
- * @property {CommandArgsOption} args
+ * @property {CommandArgsOption} options
  * @typedef {(Object)} CommandArgsOption
  */
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -253,7 +253,7 @@ declare module 'gcommands' {
     public prompt: String;
     public required: Boolean;
     public choices: Array;
-    public args: Array<CommandArgsOption>;
+    public options: Array<CommandArgsOption>;
 
     public setName(name: String): CommandArgsOptionBuilder;
     public setDescription(description: String): CommandArgsOptionBuilder;
@@ -262,8 +262,8 @@ declare module 'gcommands' {
     public setRequired(required: Boolean): CommandArgsOptionBuilder;
     public addChoice(choice: CommandArgsChoice): CommandArgsOptionBuilder;
     public addChoices(choices: Array<CommandArgsChoice>): CommandArgsOptionBuilder;
-    public addArg(arg: CommandArgsOption): CommandArgsOptionBuilder;
-    public addArgs(args: Array<CommandArgsOption>): CommandArgsOptionBuilder;
+    public addOption(option: CommandArgsOption): CommandArgsOptionBuilder;
+    public addOptions(options: Array<CommandArgsOption>): CommandArgsOptionBuilder;
     public toJSON(): CommandArgsOptionBuilder;
   }
 
@@ -502,7 +502,6 @@ declare module 'gcommands' {
     channel: TextChannel | NewsChannel;
     args: Array;
     objectArgs: Object;
-    subcommands: Array<string>;
 
     respond(options: string | GPayloadOptions): void;
     edit(options: string | GPayloadOptions): void;
@@ -554,7 +553,7 @@ declare module 'gcommands' {
     context?: GCommandsOptionsCommandsContext;
   }
 
-  type GCommandsOptionsCommandsSlash = 'both' | 'true' | 'false';
+  type GCommandsOptionsCommandsSlash = 'both' | 'slash' | 'message' | 'false';
   type GCommandsOptionsCommandsContext = 'both' | 'user' | 'message' | 'false';
 
   interface EventOptions {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR fixes `eslint`, `typings`, `slash & context` and `builders`.

Slash & context: 
-Options set in commands now override the default options in the GCommandsClient.
-You are now able to turn off commands (slash & message) completely. (for context menu only)

**Status and versioning classification:**
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)