### PR TITLE
Fix GMessage and Arguments

### DIFF
--- a/src/commands/base.js
+++ b/src/commands/base.js
@@ -55,6 +55,12 @@ class Command {
         this.args = options.args;
 
         /**
+         * AlwaysObtain
+         * @type {boolean}
+         */
+         this.alwaysObtain = options.alwaysObtain ? Boolean(options.alwaysObtain) : false;
+
+        /**
          * MinArgs
          * @type {number}
          * @deprecated use args

--- a/src/managers/GEventHandling.js
+++ b/src/managers/GEventHandling.js
@@ -233,7 +233,7 @@ class GEventHandling {
                     let arg = new Argument(this.client, cmdArgs[i]);
                     if (arg.type === 'invalid') continue;
 
-                    if (args[i]) {
+                    if (args[i] && !commandos.alwaysObtain) {
                         let argInvalid = await arg.argument.validate(arg, { content: args[i], guild: message.guild });
                         if (argInvalid) {
                             let argInput = await arg.obtain(message, argInvalid);

--- a/src/managers/GEventHandling.js
+++ b/src/managers/GEventHandling.js
@@ -232,9 +232,10 @@ class GEventHandling {
                 for (let i in cmdArgs) {
                     let arg = new Argument(this.client, cmdArgs[i]);
                     if (arg.type === 'invalid') continue;
+                    const rawArg = cmdArgs[1] ? args[i] : args.join(' ');
 
-                    if (args[i] && !commandos.alwaysObtain) {
-                        let argInvalid = await arg.argument.validate(arg, { content: args[i], guild: message.guild });
+                    if (rawArg && !commandos.alwaysObtain) {
+                        let argInvalid = await arg.argument.validate(arg, { content: rawArg, guild: message.guild });
                         if (argInvalid) {
                             let argInput = await arg.obtain(message, argInvalid);
                             if (!argInput.valid) argInput = await validArg(arg, argInput.prompt);
@@ -254,13 +255,13 @@ class GEventHandling {
                                 }
                             }
                         } else {
-                            finalArgs.push(args[i]);
+                            finalArgs.push(rawArg);
 
-                            if (ifNotSubOrGroup) objectArgs.push({ name: arg.name, value: args[i], type: arg.type });
+                            if (ifNotSubOrGroup) objectArgs.push({ name: arg.name, value: rawArg, type: arg.type });
 
                             for (const input of missingInput) {
                                 if (input.name === arg.name) {
-                                    input.value = args[i];
+                                    input.value = rawArg;
                                 }
                             }
                         }

--- a/src/structures/CommandOptionsBuilder.js
+++ b/src/structures/CommandOptionsBuilder.js
@@ -4,362 +4,377 @@ const { resolveString } = require('../util/util');
  * The CommandOptionsBuilder class
  */
 class CommandOptionsBuilder {
-    /**
-     * Creates new CommandOptionsBuilder instance
-     * @param {CommandOptions} data
-    */
-    constructor(data = {}) {
-        this.setup(data);
-    }
+  /**
+   * Creates new CommandOptionsBuilder instance
+   * @param {CommandOptions} data
+  */
+  constructor(data = {}) {
+    this.setup(data);
+  }
 
+  /**
+   * Setup
+   * @param {CommandOptions} data
+   * @returns {CommandOptions}
+   * @private
+   */
+  setup(data) {
     /**
-     * Setup
-     * @param {CommandOptions} data
-     * @returns {CommandOptions}
-     * @private
+      * Name
+      * @type {string}
      */
-    setup(data) {
-       /**
-         * Name
-         * @type {string}
-        */
-       this.name = 'name' in data ? resolveString(data.name) : null;
-
-       /**
-         * ContextMenuName
-         * @type {string}
-        */
-       this.contextMenuName = 'contextMenuName' in data ? resolveString(data.contextMenuName) : null;
-
-       /**
-         * Description
-         * @type {string}
-        */
-       this.description = 'description' in data ? resolveString(data.description) : null;
-
-        /**
-         * Usage
-         * @type {string}
-        */
-       this.usage = 'usage' in data ? resolveString(data.usage) : null;
-
-       /**
-         * Args
-         * @type {Array<CommandArgsOption>}
-        */
-       this.args = 'args' in data ? data.args : null;
-
-       /**
-         * Cooldown
-         * @type {string}
-        */
-       this.cooldown = 'cooldown' in data ? resolveString(data.cooldown) : null;
-
-       /**
-         * Category
-         * @type {string}
-        */
-       this.category = 'category' in data ? resolveString(data.category) : null;
-
-       /**
-         * Aliases
-         * @type {Array}
-        */
-       this.aliases = 'aliases' in data ? data.aliases : null;
-
-       /**
-         * User
-         * @type {string | Array}
-        */
-       this.userRequiredPermissions = 'userRequiredPermissions' in data ? data.userRequiredPermissions : null;
-
-       /**
-         * UserRequiredRoles
-         * @type {string | Array}
-        */
-       this.userRequiredRoles = 'userRequiredRoles' in data ? data.userRequiredRoles : null;
-
-       /**
-         * ClientRequiredPermissions
-         * @type {string | Array}
-        */
-       this.clientRequiredPermissions = 'clientRequiredPermissions' in data ? data.clientRequiredPermissions : null;
-
-       /**
-         * UserOnly
-         * @type {Snowflake | Array}
-        */
-       this.userOnly = 'userOnly' in data ? data.userOnly : null;
-
-       /**
-         * ChannelOnly
-         * @type {Snowflake | Array}
-        */
-       this.channelOnly = 'channelOnly' in data ? data.channelOnly : null;
-
-       /**
-         * GuildOnly
-         * @type {Snowflake}
-        */
-       this.guildOnly = 'guildOnly' in data ? data.guildOnly : null;
-
-       /**
-         * ChannelTextOnly
-         * @type {boolean}
-        */
-       this.channelTextOnly = 'channelTextOnly' in data ? Boolean(data.channelTextOnly) : null;
-
-       /**
-         * ChannelNewsOnly
-         * @type {boolean}
-        */
-       this.channelNewsOnly = 'channelNewsOnly' in data ? Boolean(data.channelNewsOnly) : null;
-
-       /**
-         * ChannelThreadOnly
-         * @type {boolean}
-        */
-       this.channelThreadOnly = 'channelThreadOnly' in data ? Boolean(data.channelThreadOnly) : null;
-
-       /**
-         * Nsfw
-         * @type {boolean}
-        */
-       this.nsfw = 'nsfw' in data ? Boolean(data.nsfw) : null;
-
-       /**
-         * Slash
-         * @type {boolean}
-        */
-       this.slash = 'slash' in data ? Boolean(data.slash) : null;
-
-       /**
-         * Context
-         * @type {string | boolean}
-        */
-       this.context = 'context' in data ? data.context : null;
-
-       return this.toJSON();
-    }
+    this.name = 'name' in data ? resolveString(data.name) : null;
 
     /**
-     * Method to setName
-     * @param {string} name
-    */
-    setName(name) {
-        this.name = resolveString(name);
-        return this;
-    }
+      * ContextMenuName
+      * @type {string}
+     */
+    this.contextMenuName = 'contextMenuName' in data ? resolveString(data.contextMenuName) : null;
 
     /**
-     * Method to setContextMenuName
-     * @param {string} contextMenuName
-    */
-    setContextMenuName(contextMenuName) {
-      this.contextMenuName = resolveString(contextMenuName);
-      return this;
-    }
+      * Description
+      * @type {string}
+     */
+    this.description = 'description' in data ? resolveString(data.description) : null;
 
     /**
-     * Method to setDescription
-     * @param {string} description
+     * Usage
+     * @type {string}
     */
-    setDescription(description) {
-        this.description = resolveString(description);
-        return this;
-    }
+    this.usage = 'usage' in data ? resolveString(data.usage) : null;
 
     /**
-     * Method to setUsage
-     * @param {string} usage
-    */
-    setUsage(usage) {
-      this.usage = resolveString(usage);
-      return this;
-    }
+      * Args
+      * @type {Array<CommandArgsOption>}
+     */
+    this.args = 'args' in data ? data.args : null;
 
     /**
-     * Method to addArg
-     * @param {CommandArgsOption} arg
-    */
-    addArg(arg) {
-      if (!Array.isArray(this.args)) this.args = [];
-      this.args.push(arg);
-      return this;
-    }
+      * AlwaysObtain
+      * @type {boolean}
+     */
+    this.alwaysObtain = 'alwaysObtain' in data ? data.alwaysObtain : null;
 
     /**
-     * Method to addArgs
-     * @param {Array<CommandArgsOption>} args
-    */
-    addArgs(args) {
-      for (const arg of Object.values(args)) {
-        this.addArg(arg);
-      }
-      return this;
-    }
+      * Cooldown
+      * @type {string}
+     */
+    this.cooldown = 'cooldown' in data ? resolveString(data.cooldown) : null;
 
     /**
-     * Method to setCooldown
-     * @param {string} cooldown
-    */
-    setCooldown(cooldown) {
-      this.cooldown = resolveString(cooldown);
-      return this;
-    }
+      * Category
+      * @type {string}
+     */
+    this.category = 'category' in data ? resolveString(data.category) : null;
 
     /**
-     * Method to setCategory
-     * @param {string} category
-    */
-    setCategory(category) {
-      this.category = resolveString(category);
-      return this;
-    }
+      * Aliases
+      * @type {Array}
+     */
+    this.aliases = 'aliases' in data ? data.aliases : null;
 
     /**
-     * Method to setAliases
-     * @param {Array} aliases
-    */
-    setAliases(aliases) {
-      this.aliases = aliases;
-      return this;
-    }
+      * User
+      * @type {string | Array}
+     */
+    this.userRequiredPermissions = 'userRequiredPermissions' in data ? data.userRequiredPermissions : null;
 
     /**
-     * Method to setUserRequiredPermissions
-     * @param {string | Array} permissions
-    */
-    setUserRequiredPermissions(permissions) {
-      this.userRequiredPermissions = permissions;
-      return this;
-    }
+      * UserRequiredRoles
+      * @type {string | Array}
+     */
+    this.userRequiredRoles = 'userRequiredRoles' in data ? data.userRequiredRoles : null;
 
     /**
-     * Method to setUserRequiredRoles
-     * @param {string | Array} roles
-    */
-    setUserRequiredRoles(roles) {
-      this.userRequiredRoles = roles;
-      return this;
-    }
+      * ClientRequiredPermissions
+      * @type {string | Array}
+     */
+    this.clientRequiredPermissions = 'clientRequiredPermissions' in data ? data.clientRequiredPermissions : null;
 
     /**
-     * Method to setClientRequiredPermissions
-     * @param {string | Array} permissions
-    */
-    setClientRequiredPermissions(permissions) {
-      this.clientRequiredPermissions = permissions;
-      return this;
-    }
+      * UserOnly
+      * @type {Snowflake | Array}
+     */
+    this.userOnly = 'userOnly' in data ? data.userOnly : null;
 
     /**
-     * Method to setUserOnly
-     * @param {Snowflake | Array} userOnly
-    */
-    setUserOnly(userOnly) {
-      this.userOnly = userOnly;
-      return this;
-    }
+      * ChannelOnly
+      * @type {Snowflake | Array}
+     */
+    this.channelOnly = 'channelOnly' in data ? data.channelOnly : null;
 
     /**
-     * Method to setChannelOnly
-     * @param {Snowflake | Array} channelOnly
-    */
-    setChannelOnly(channelOnly) {
-      this.channelOnly = channelOnly;
-      return this;
-    }
+      * GuildOnly
+      * @type {Snowflake}
+     */
+    this.guildOnly = 'guildOnly' in data ? data.guildOnly : null;
 
     /**
-     * Method to setGuildOnly
-     * @param {Snowflake | Array} guildOnly
-    */
-    setGuildOnly(guildOnly) {
-      this.guildOnly = guildOnly;
-      return this;
-    }
+      * ChannelTextOnly
+      * @type {boolean}
+     */
+    this.channelTextOnly = 'channelTextOnly' in data ? Boolean(data.channelTextOnly) : null;
 
     /**
-     * Method to setChannelTextOnly
-     * @param {boolean} channelTextOnly
-    */
-    setChannelTextOnly(channelTextOnly) {
-      this.channelTextOnly = Boolean(channelTextOnly);
-      return this;
-    }
+      * ChannelNewsOnly
+      * @type {boolean}
+     */
+    this.channelNewsOnly = 'channelNewsOnly' in data ? Boolean(data.channelNewsOnly) : null;
 
     /**
-     * Method to setChannelNewsOnly
-     * @param {boolean} channelNewsOnly
-    */
-    setChannelNewsOnly(channelNewsOnly) {
-      this.channelNewsOnly = Boolean(channelNewsOnly);
-      return this;
-    }
+      * ChannelThreadOnly
+      * @type {boolean}
+     */
+    this.channelThreadOnly = 'channelThreadOnly' in data ? Boolean(data.channelThreadOnly) : null;
 
     /**
-     * Method to setChannelThreadOnly
-     * @param {boolean} channelThreadOnly
-    */
-    setChannelThreadOnly(channelThreadOnly) {
-      this.channelThreadOnly = Boolean(channelThreadOnly);
-      return this;
-    }
+      * Nsfw
+      * @type {boolean}
+     */
+    this.nsfw = 'nsfw' in data ? Boolean(data.nsfw) : null;
 
     /**
-     * Method to setNsfw
-     * @param {boolean} nsfw
-    */
-    setNsfw(nsfw) {
-      this.nsfw = Boolean(nsfw);
-      return this;
-    }
+      * Slash
+      * @type {boolean}
+     */
+    this.slash = 'slash' in data ? Boolean(data.slash) : null;
 
     /**
-     * Method to setSlash
-     * @param {boolean} slash
-    */
-    setSlash(slash) {
-      this.slash = Boolean(slash);
-      return this;
-    }
+      * Context
+      * @type {string | boolean}
+     */
+    this.context = 'context' in data ? data.context : null;
 
-    /**
-     * Method to setContext
-     * @param {string | boolean} context
-    */
-    setContext(context) {
-      this.context = Boolean(context);
-      return this;
-    }
+    return this.toJSON();
+  }
 
-    /**
-     * Method to toJSON
-     * @returns {Object}
-    */
-    toJSON() {
-      return {
-        name: this.name,
-        description: this.description,
-        usage: this.usage,
-        cooldown: this.cooldown,
-        category: this.category,
-        aliases: this.aliases,
-        userRequiredPermissions: this.userRequiredPermissions,
-        userRequiredRoles: this.userRequiredRoles,
-        clientRequiredPermissions: this.clientRequiredPermissions,
-        userOnly: this.userOnly,
-        channelOnly: this.channelOnly,
-        guildOnly: this.guildOnly,
-        channelTextOnly: this.channelTextOnly,
-        channelNewsOnly: this.channelNewsOnly,
-        channelThreadOnly: this.channelThreadOnly,
-        nsfw: this.nsfw,
-        slash: this.slash,
-        context: this.context,
-      };
+  /**
+   * Method to setName
+   * @param {string} name
+  */
+  setName(name) {
+    this.name = resolveString(name);
+    return this;
+  }
+
+  /**
+   * Method to setContextMenuName
+   * @param {string} contextMenuName
+  */
+  setContextMenuName(contextMenuName) {
+    this.contextMenuName = resolveString(contextMenuName);
+    return this;
+  }
+
+  /**
+   * Method to setDescription
+   * @param {string} description
+  */
+  setDescription(description) {
+    this.description = resolveString(description);
+    return this;
+  }
+
+  /**
+   * Method to setUsage
+   * @param {string} usage
+  */
+  setUsage(usage) {
+    this.usage = resolveString(usage);
+    return this;
+  }
+
+  /**
+   * Method to addArg
+   * @param {CommandArgsOption} arg
+  */
+  addArg(arg) {
+    if (!Array.isArray(this.args)) this.args = [];
+    this.args.push(arg);
+    return this;
+  }
+
+  /**
+   * Method to addArgs
+   * @param {Array<CommandArgsOption>} args
+  */
+  addArgs(args) {
+    for (const arg of Object.values(args)) {
+      this.addArg(arg);
     }
+    return this;
+  }
+
+  /**
+   * Method to setAlwaysObtain
+   * @param {boolean} alwaysObtain
+  */
+  setAlwaysObtain(alwaysObtain) {
+    this.alwaysObtain = Boolean(alwaysObtain);
+    return this;
+  }
+
+  /**
+   * Method to setCooldown
+   * @param {string} cooldown
+  */
+  setCooldown(cooldown) {
+    this.cooldown = resolveString(cooldown);
+    return this;
+  }
+
+  /**
+   * Method to setCategory
+   * @param {string} category
+  */
+  setCategory(category) {
+    this.category = resolveString(category);
+    return this;
+  }
+
+  /**
+   * Method to setAliases
+   * @param {Array} aliases
+  */
+  setAliases(aliases) {
+    this.aliases = aliases;
+    return this;
+  }
+
+  /**
+   * Method to setUserRequiredPermissions
+   * @param {string | Array} permissions
+  */
+  setUserRequiredPermissions(permissions) {
+    this.userRequiredPermissions = permissions;
+    return this;
+  }
+
+  /**
+   * Method to setUserRequiredRoles
+   * @param {string | Array} roles
+  */
+  setUserRequiredRoles(roles) {
+    this.userRequiredRoles = roles;
+    return this;
+  }
+
+  /**
+   * Method to setClientRequiredPermissions
+   * @param {string | Array} permissions
+  */
+  setClientRequiredPermissions(permissions) {
+    this.clientRequiredPermissions = permissions;
+    return this;
+  }
+
+  /**
+   * Method to setUserOnly
+   * @param {Snowflake | Array} userOnly
+  */
+  setUserOnly(userOnly) {
+    this.userOnly = userOnly;
+    return this;
+  }
+
+  /**
+   * Method to setChannelOnly
+   * @param {Snowflake | Array} channelOnly
+  */
+  setChannelOnly(channelOnly) {
+    this.channelOnly = channelOnly;
+    return this;
+  }
+
+  /**
+   * Method to setGuildOnly
+   * @param {Snowflake | Array} guildOnly
+  */
+  setGuildOnly(guildOnly) {
+    this.guildOnly = guildOnly;
+    return this;
+  }
+
+  /**
+   * Method to setChannelTextOnly
+   * @param {boolean} channelTextOnly
+  */
+  setChannelTextOnly(channelTextOnly) {
+    this.channelTextOnly = Boolean(channelTextOnly);
+    return this;
+  }
+
+  /**
+   * Method to setChannelNewsOnly
+   * @param {boolean} channelNewsOnly
+  */
+  setChannelNewsOnly(channelNewsOnly) {
+    this.channelNewsOnly = Boolean(channelNewsOnly);
+    return this;
+  }
+
+  /**
+   * Method to setChannelThreadOnly
+   * @param {boolean} channelThreadOnly
+  */
+  setChannelThreadOnly(channelThreadOnly) {
+    this.channelThreadOnly = Boolean(channelThreadOnly);
+    return this;
+  }
+
+  /**
+   * Method to setNsfw
+   * @param {boolean} nsfw
+  */
+  setNsfw(nsfw) {
+    this.nsfw = Boolean(nsfw);
+    return this;
+  }
+
+  /**
+   * Method to setSlash
+   * @param {boolean} slash
+  */
+  setSlash(slash) {
+    this.slash = Boolean(slash);
+    return this;
+  }
+
+  /**
+   * Method to setContext
+   * @param {string | boolean} context
+  */
+  setContext(context) {
+    this.context = Boolean(context);
+    return this;
+  }
+
+  /**
+   * Method to toJSON
+   * @returns {Object}
+  */
+  toJSON() {
+    return {
+      name: this.name,
+      description: this.description,
+      usage: this.usage,
+      cooldown: this.cooldown,
+      category: this.category,
+      aliases: this.aliases,
+      userRequiredPermissions: this.userRequiredPermissions,
+      userRequiredRoles: this.userRequiredRoles,
+      clientRequiredPermissions: this.clientRequiredPermissions,
+      userOnly: this.userOnly,
+      channelOnly: this.channelOnly,
+      guildOnly: this.guildOnly,
+      channelTextOnly: this.channelTextOnly,
+      channelNewsOnly: this.channelNewsOnly,
+      channelThreadOnly: this.channelThreadOnly,
+      nsfw: this.nsfw,
+      slash: this.slash,
+      context: this.context,
+    };
+  }
 }
 
 module.exports = CommandOptionsBuilder;

--- a/src/structures/GMessage.js
+++ b/src/structures/GMessage.js
@@ -230,7 +230,7 @@ class GMessage {
             },
 
             reply: {
-                value: async function(result) {
+                value: async function(result = {}) {
                     if (typeof result === 'string') result = { content: result, inlineReply: this.id };
                     else if (result.inlineReply === undefined || result.inlineReply === true) result.inlineReply = this.id;
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -205,6 +205,7 @@ declare module 'gcommands' {
     public description: string;
     public cooldown: string;
     public args: Array<CommandArgsOption>;
+    public alwaysObtain: boolean;
     public clientRequiredPermissions: String | Array<string>;
     public userRequiredPermissions: String | Array<string>;
     public userRequiredRoles: String | Array<Snowflake>;
@@ -227,6 +228,7 @@ declare module 'gcommands' {
     public setCooldown(cooldown: string): CommandOptionsBuilder;
     public addArg(arg: CommandArgsOption): CommandOptionsBuilder;
     public addArgs(args: Array<CommandArgsOption>): CommandOptionsBuilder;
+    public setAlwaysObtain(alwaysObtain: boolean): CommandOptionsBuilder;
     public setClientRequiredPermissions(permissions: string | Array<string>): CommandOptionsBuilder;
     public setUserRequiredPermissions(permissions: string | Array<string>): CommandOptionsBuilder;
     public setUserRequiredRoles(permissions: string | Array<Snowflake>): CommandOptionsBuilder;
@@ -408,6 +410,7 @@ declare module 'gcommands' {
     public description: string;
     public cooldown: string;
     public args: Array<object>;
+    public alwaysObtain: boolean;
     public clientRequiredPermissions: String | Array<string>;
     public userRequiredPermissions: String | Array<string>;
     public userRequiredRoles: String | Array<Snowflake>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR adds the `alwaysObtain` option. If `alwaysObtain` is set to true, any arguments (excluding subcommand) will be asked again so the message can be multiple words, instead of just one.

Without `alwaysObtain` (if command has multiple arguments)
![image](https://user-images.githubusercontent.com/68066476/132983147-c36bdefb-6565-4c19-b11e-1ee32e4092f1.png)

With `alwaysObtain` (if command has multiple arguments)
![image](https://user-images.githubusercontent.com/68066476/132983173-bdf11176-2f5a-45e7-a295-c2e39a974f37.png)

For commands with only 1 argument, all given arguments will be used instead of just one.

This PR also fixes an issue with `GMessage`, where the error (cannot send an empty message) would be displayed as another error.


**Status and versioning classification:**
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)