### PR TITLE
Fix: Apply split('.') tweak to __loadCommandCategoryFiles

### DIFF
--- a/src/managers/GCommandLoader.js
+++ b/src/managers/GCommandLoader.js
@@ -85,8 +85,9 @@ class GCommandLoader {
      */
     async __loadCommandCategoryFiles(categoryFolder) {
         for await (let file of (await fs.readdirSync(`${this.cmdDir}/${categoryFolder}`))) {
-            const fileName = file.split('.').reverse()[1];
-            const fileType = file.split('.').reverse()[0];
+            const fileTypeIndex = (file.lastIndexOf('.') - 1 >>> 0) + 2;
+            const fileName = file.slice(0, fileTypeIndex - 1);
+            const fileType = file.slice(fileTypeIndex);
 
             file = await require(`${this.cmdDir}/${categoryFolder}/${file}`);
             if (isClass(file)) {


### PR DESCRIPTION
split('.') will unintentionally create more splits with filenames that contain more than one period

Follow-up to #160, didn't see that there was similar code still in use 