### PR TITLE
fix(slash permissions & error.response.status) + feat(loadFromCache)

### DIFF
--- a/src/base/GCommandsClient.js
+++ b/src/base/GCommandsClient.js
@@ -127,6 +127,13 @@ class GCommandsClient extends Client {
         this.context = options.commands.context ? options.commands.context : false;
 
         /**
+         * LoadFromCache
+         * @type {boolean}
+         * @default true
+         */
+        this.loadFromCache = options.commands.loadFromCache !== undefined ? Boolean(options.commands.loadFromCache) : true;
+
+        /**
          * DefaultCooldown
          * @type {number}
          * @default 0

--- a/src/managers/GCommandLoader.js
+++ b/src/managers/GCommandLoader.js
@@ -141,7 +141,7 @@ class GCommandLoader {
                         description: cmd.description,
                         options: cmd.args || [],
                         type: 1,
-                        default_permission: (Object.values(cmd)[10] || Object.values(cmd)[12]) !== undefined ? guildOnly === undefined : true,
+                        default_permission: guildOnly ? (Object.values(cmd)[10] || Object.values(cmd)[12]) === undefined : true,
                     },
                     url,
                 };

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -205,8 +205,8 @@ function createEnum(keys) {
  * @property {GCommandsOptionsCommandsSlash} slash
  * @property {GCommandsOptionsCommandsContext} context
  * @property {string} prefix
+ * @property {boolean} loadFromCache
  * @typedef {(object)} GCommandsOptionsCommands
- * @typedef {(Object)} GCommandsOptionsCommands
  */
 
 /**

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -492,6 +492,7 @@ declare module 'gcommands' {
       slash: GCommandsOptionsCommandsSlash;
       context?: GCommandsOptionsCommandsContext;
       prefix?: string;
+      loadFromCache?: boolean;
     },
     caseSensitiveCommands?: boolean;
     caseSensitivePrefixes?: boolean;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR fixes the following:
- Problem with global slash commands greying out when they should not be.
- Problem in the `GCommandLoader` resulting in a error (`error.response.status`).

This PR adds the following features:
- `loadFromCache` option in the `GCommandsClient#commands`, this feature disables/enables loading from cache.

```js
// This will load from cache
new GCommandsClient({
    ...options
    commands: {
        loadFromCache: true, // loadFromCache is set to true by default
    }
});

// This will not load from cache
new GCommandsClient({
    ...options
    commands: {
        loadFromCache: false,
    }
});
```

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->