### PR TITLE
Change to using path for fileName and fileType in GCommandLoader, fix directory scanning

### DIFF
--- a/src/managers/GCommandLoader.js
+++ b/src/managers/GCommandLoader.js
@@ -58,7 +58,7 @@ class GCommandLoader {
             if (fsDirent.isDirectory()) {
                 await this.__loadCommandCategoryFiles(file);
                 continue;
-            } else if (!['js', 'ts'].includes(fileType)) { continue; }
+            } else if (!['.js', '.ts'].includes(fileType)) { continue; }
 
             file = await require(`${this.cmdDir}/${file}`);
             if (isClass(file)) {
@@ -96,7 +96,7 @@ class GCommandLoader {
                 // Recursive scan
                 await this.__loadCommandCategoryFiles(`${categoryFolder}/${file}`);
                 continue;
-            } else if (!['js', 'ts'].includes(fileType)) { continue; }
+            } else if (!['.js', '.ts'].includes(fileType)) { continue; }
 
             file = await require(`${this.cmdDir}/${categoryFolder}/${file}`);
             if (isClass(file)) {

--- a/src/managers/GCommandLoader.js
+++ b/src/managers/GCommandLoader.js
@@ -87,9 +87,8 @@ class GCommandLoader {
     async __loadCommandCategoryFiles(categoryFolder) {
         for await (let fsDirent of fs.readdirSync(`${this.cmdDir}/${categoryFolder}`, { withFileTypes: true })) {
             let file = fsDirent.name;
-            // Note: fileName includes the extension (.)
-            const fileName = path.basename(file);
             const fileType = path.extname(file);
+            const fileName = path.basename(file, fileType);
 
             if (fsDirent.isDirectory()) {
                 // Recursive scan

--- a/src/managers/GCommandLoader.js
+++ b/src/managers/GCommandLoader.js
@@ -72,9 +72,9 @@ class GCommandLoader {
             this.GCommandsClient.emit(Events.LOG, new Color(`&d[GCommands] &aLoaded (File): &e➜   &3${fileName}`, { json: false }).getText());
         }
 
-        this.__loadSlashCommands();
-        this.__loadContextMenuCommands();
-        this.__loadCommandPermissions();
+        await this.__loadSlashCommands();
+        await this.__loadContextMenuCommands();
+        await this.__loadCommandPermissions();
 
         this.client.emit(Events.COMMANDS_LOADED, this.client.gcommands);
     }

--- a/src/managers/GCommandLoader.js
+++ b/src/managers/GCommandLoader.js
@@ -1,5 +1,6 @@
 const Color = require('../structures/Color'), GError = require('../structures/GError'), { Events, ApplicationCommandTypesRaw } = require('../util/Constants');
 const axios = require('axios');
+const path = require('path');
 const fs = require('fs');
 const ms = require('ms');
 const { isClass, __deleteCmd, __getAllCommands, comparable, getAllObjects } = require('../util/util');
@@ -49,9 +50,9 @@ class GCommandLoader {
      */
     async __loadCommandFiles() {
         for await (let file of (await fs.readdirSync(this.cmdDir))) {
-            const fileTypeIndex = (file.lastIndexOf('.') - 1 >>> 0) + 2;
-            const fileName = file.slice(0, fileTypeIndex - 1);
-            const fileType = file.slice(fileTypeIndex);
+            // Note: fileName includes the extension (.)
+            const fileName = path.basename(file);
+            const fileType = path.extname(file);
 
             if (!['js', 'ts'].includes(fileType)) {
                 await this.__loadCommandCategoryFiles(file);
@@ -64,7 +65,7 @@ class GCommandLoader {
                 if (!(file instanceof Command)) throw new GError('[COMMAND]', `Command ${fileName} doesnt belong in Commands.`);
             }
 
-            file._path = `${this.cmdDir}/${fileName}.${fileType}`;
+            file._path = `${this.cmdDir}/${fileName}`;
 
             this.client.gcommands.set(file.name, file);
             if (file && file.aliases && Array.isArray(file.aliases)) file.aliases.forEach(alias => this.client.galiases.set(alias, file.name));
@@ -85,8 +86,9 @@ class GCommandLoader {
      */
     async __loadCommandCategoryFiles(categoryFolder) {
         for await (let file of (await fs.readdirSync(`${this.cmdDir}/${categoryFolder}`))) {
-            const fileName = file.split('.').reverse()[1];
-            const fileType = file.split('.').reverse()[0];
+            // Note: fileName includes the extension (.)
+            const fileName = path.basename(file);
+            const fileType = path.extname(file);
 
             file = await require(`${this.cmdDir}/${categoryFolder}/${file}`);
             if (isClass(file)) {
@@ -94,7 +96,7 @@ class GCommandLoader {
                 if (!(file instanceof Command)) throw new GError('[COMMAND]', `Command ${fileName} doesnt belong in Commands.`);
             }
 
-            file._path = `${this.cmdDir}/${categoryFolder}/${fileName}.${fileType}`;
+            file._path = `${this.cmdDir}/${categoryFolder}/${fileName}`;
 
             this.client.gcommands.set(file.name, file);
             if (file && file.aliases && Array.isArray(file.aliases)) file.aliases.forEach(alias => this.client.galiases.set(alias, file.name));


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR fixes the following:
- fileName and fileType is now determined from the path module (path.basename, path.extname)
- Directory scanning should now recurse through all subdirectories, regardless of depth
- Filetype matching fixed, any files that don't end with .js or .ts will be ignored, any files that're directories will be further scanned for commands