### PR TITLE
fix(Arguments): Arguments return correct value

### DIFF
--- a/src/commands/argument.js
+++ b/src/commands/argument.js
@@ -67,9 +67,7 @@ class Argument {
          * SubCommands
          * @type {Array<Object>}
         */
-         this.subcommands = argument.subcommands;
-
-        return this;
+        this.subcommands = argument.subcommands;
     }
 
     /**
@@ -81,7 +79,7 @@ class Argument {
         if (message.author.bot) return;
 
         const guildLanguage = await message.guild.getLanguage();
-		const wait = 30000;
+        const wait = 30000;
 
         if (!this.required) prompt += `\n${this.client.languageFile.ARGS_OPTIONAL[guildLanguage]}`;
         if ((this.type === 'sub_command' || 'sub_command_group') && this.subcommands) prompt = this.client.languageFile.ARGS_COMMAND[guildLanguage].replace('{choices}', this.subcommands.map(sc => `\`${sc.name}\``).join(', '));
@@ -91,8 +89,8 @@ class Argument {
         const responses = await (ifDjsV13 ? message.channel.awaitMessages({ filter, max: 1, time: wait }) : message.channel.awaitMessages(filter, { max: 1, time: wait }));
         if (responses.size === 0) {
             return {
-                        valid: true,
-                        timeLimit: true,
+                valid: true,
+                timeLimit: true,
             };
         }
 
@@ -109,19 +107,9 @@ class Argument {
             };
         }
 
-        let content = resFirst.content;
-        if (this.choices) {
-            const choice = this.choices.find(ch => ch.name === resFirst.content.toLowerCase());
-            if (choice) content = choice.value;
-        }
-        if (this.subcommands) {
-            const subcommand = this.subcommands.find(sc => sc.name === resFirst.content.toLowerCase());
-            if (subcommand) content = subcommand;
-        }
-
         return {
             valid: true,
-            content: content,
+            content: this.get(resFirst),
         };
     }
 
@@ -142,6 +130,15 @@ class Argument {
         if (argument.type === 9) return new MentionableArgumentType(client, argument);
         if (argument.type === 10) return new NumberArgumentType(client, argument);
         else return { type: 'invalid' };
+    }
+
+    /**
+     * Method to get
+     * @param {object | string} message
+     */
+    get(message) {
+        if (typeof message === 'string') return this.argument.get(this, message.toLowerCase());
+        else return this.argument.get(this, message.content.toLowerCase());
     }
 }
 

--- a/src/commands/types/base.js
+++ b/src/commands/types/base.js
@@ -10,8 +10,8 @@ class ArgumentType {
      * @param {string} type
      */
     constructor(client, type) {
-        if (!client) throw new GError('[ARGUMENTS]','You must specify the client');
-        if (!type) throw new GError('[ARGUMENTS]','You must specify the argument type');
+        if (!client) throw new GError('[ARGUMENTS]', 'You must specify the client');
+        if (!type) throw new GError('[ARGUMENTS]', 'You must specify the argument type');
 
         /**
          * Type
@@ -34,7 +34,16 @@ class ArgumentType {
      * @param {Message|Object}
      */
     validate(argument, message) { // eslint-disable-line no-unused-vars, require-await
-        throw new GError('[ARGUMENTS]','Argument doesnt have provided validate() method');
+        throw new GError('[ARGUMENTS]', 'Argument doesnt have provided validate() method');
+    }
+
+    /**
+     * Method to get
+     * @param {Argument}
+     * @param {Message|Object}
+    */
+    get(argument, message) { // eslint-disable-line no-unused-vars, require-await
+        throw new GError('[ARGUMENTS]', 'Argument doesnt have provided get() method');
     }
 }
 

--- a/src/commands/types/boolean.js
+++ b/src/commands/types/boolean.js
@@ -33,6 +33,9 @@ class BooleanArgumentType extends ArgumentType {
 			return this.client.languageFile.ARGS_MUST_CONTAIN[guildLanguage].replace('{argument}', argument.name).replace('{type}', 'boolean');
 		}
 	}
+    get(argument, message) {
+        return Boolean(message);
+    }
 }
 
 module.exports = BooleanArgumentType;

--- a/src/commands/types/channel.js
+++ b/src/commands/types/channel.js
@@ -28,6 +28,9 @@ class ChannelArgumentType extends ArgumentType {
 		let channel = this.client.channels.cache.get(matches[1]);
 		if (!channel) return this.client.languageFile.ARGS_MUST_CONTAIN[guildLanguage].replace('{argument}', argument.name).replace('{type}', 'channel');
 	}
+    get(argument, message) {
+        return message.match(/([0-9]+)/)[0];
+    }
 }
 
 module.exports = ChannelArgumentType;

--- a/src/commands/types/integer.js
+++ b/src/commands/types/integer.js
@@ -26,6 +26,9 @@ class IntegerArgumentType extends ArgumentType {
 
 		if (argument.choices && !argument.choices.some(ch => ch.name === message.content.toLowerCase())) { return this.client.languageFile.ARGS_CHOICES[guildLanguage].replace('{choices}', argument.choices.map(opt => `\`${opt.name}\``).join(', ')); }
 	}
+    get(argument, message) {
+        return parseInt(message);
+    }
 }
 
 module.exports = IntegerArgumentType;

--- a/src/commands/types/mentionable.js
+++ b/src/commands/types/mentionable.js
@@ -29,6 +29,9 @@ class MentionableArgumentType extends ArgumentType {
 		let user = this.client.users.cache.get(matches[1]);
 		if ((!user) && (!role)) return this.client.languageFile.ARGS_MUST_CONTAIN[guildLanguage].replace('{argument}', argument.name).replace('{type}', 'mention');
 	}
+    get(argument, message) {
+        return message.match(/([0-9]+)/)[0];
+    }
 }
 
 module.exports = MentionableArgumentType;

--- a/src/commands/types/number.js
+++ b/src/commands/types/number.js
@@ -26,6 +26,9 @@ class NumberArgumentType extends ArgumentType {
 
 		if (argument.choices && !argument.choices.some(ch => ch.name === message.content.toLowerCase())) { return this.client.languageFile.ARGS_CHOICES[guildLanguage].replace('{choices}', argument.choices.map(opt => `\`${opt.name}\``).join(', ')); }
 	}
+    get(argument, message) {
+        return Number(message);
+    }
 }
 
 module.exports = NumberArgumentType;

--- a/src/commands/types/role.js
+++ b/src/commands/types/role.js
@@ -28,6 +28,9 @@ class RoleArgumentType extends ArgumentType {
 		let role = message.guild.roles.cache.get(matches[1]);
 		if (!role) return this.client.languageFile.ARGS_MUST_CONTAIN[guildLanguage].replace('{argument}', argument.name).replace('{type}', 'role');
 	}
+    get(argument, message) {
+        return message.match(/([0-9]+)/)[0];
+    }
 }
 
 module.exports = RoleArgumentType;

--- a/src/commands/types/string.js
+++ b/src/commands/types/string.js
@@ -21,11 +21,11 @@ class StringArgumentType extends ArgumentType {
 	async validate(argument, message) {
         const guildLanguage = await message.guild.getLanguage();
 
-		if (argument.choices && !argument.choices.some(ch => ch.name === message.content.toLowerCase())) { return this.client.languageFile.ARGS_CHOICES[guildLanguage].replace('{choices}', argument.choices.map(opt => `\`${opt.name}\``).join(', ')); }
+		if (argument.choices && !argument.choices.some(ch => ch.name.toLowerCase() === message.content.toLowerCase())) { return this.client.languageFile.ARGS_CHOICES[guildLanguage].replace('{choices}', argument.choices.map(opt => `\`${opt.name}\``).join(', ')); }
 	}
     get(argument, message) {
         if (argument.choices) {
-            return argument.choices.find(ch => ch.name === message);
+            return argument.choices.find(ch => ch.name.toLowerCase() === message);
         } else {
             return message;
         }

--- a/src/commands/types/string.js
+++ b/src/commands/types/string.js
@@ -23,6 +23,13 @@ class StringArgumentType extends ArgumentType {
 
 		if (argument.choices && !argument.choices.some(ch => ch.name === message.content.toLowerCase())) { return this.client.languageFile.ARGS_CHOICES[guildLanguage].replace('{choices}', argument.choices.map(opt => `\`${opt.name}\``).join(', ')); }
 	}
+    get(argument, message) {
+        if (argument.choices) {
+            return argument.choices.find(ch => ch.name === message);
+        } else {
+            return message;
+        }
+    }
 }
 
 module.exports = StringArgumentType;

--- a/src/commands/types/sub_command.js
+++ b/src/commands/types/sub_command.js
@@ -18,11 +18,15 @@ class SubCommandArgumentType extends ArgumentType {
         this.client = client;
     }
 
-	async validate(argument, message) {
+    async validate(argument, message) {
         const guildLanguage = await message.guild.getLanguage();
 
         if (argument.subcommands && !argument.subcommands.find(sc => sc.name === message.content.toLowerCase())) { return this.client.languageFile.ARGS_COMMAND[guildLanguage].replace('{choices}', argument.subcommands.map(sc => `\`${sc.name}\``).join(', ')); }
-	}
+    }
+    get(argument, message) {
+        console.log(argument, message);
+        return argument.subcommands.find(sc => sc.name === message);
+    }
 }
 
 module.exports = SubCommandArgumentType;

--- a/src/commands/types/sub_command_group.js
+++ b/src/commands/types/sub_command_group.js
@@ -23,6 +23,9 @@ class SubCommandGroupArgumentType extends ArgumentType {
 
         if (argument.subcommands && !argument.subcommands.find(sc => sc.name === message.content.toLowerCase())) { return this.client.languageFile.ARGS_COMMAND[guildLanguage].replace('{choices}', argument.subcommands.map(sc => `\`${sc.name}\``).join(', ')); }
 	}
+    get(argument, message) {
+        return argument.subcommands.find(sc => sc.name === message);
+    }
 }
 
 module.exports = SubCommandGroupArgumentType;

--- a/src/commands/types/user.js
+++ b/src/commands/types/user.js
@@ -28,6 +28,9 @@ class UserArgumentType extends ArgumentType {
 		let user = this.client.users.cache.get(matches[1]);
 		if (!user) return this.client.languageFile.ARGS_MUST_CONTAIN[guildLanguage].replace('{argument}', argument.name).replace('{type}', 'user');
 	}
+    get(argument, message) {
+        return message.match(/([0-9]+)/)[0];
+    }
 }
 
 module.exports = UserArgumentType;

--- a/src/managers/GEventHandling.js
+++ b/src/managers/GEventHandling.js
@@ -176,7 +176,7 @@ class GEventHandling {
                         subcommands: cmdSubcommands,
                         required: true,
                     };
-                    const arg = new Argument(this.client, options);
+                    let arg = new Argument(this.client, options);
                     let subcommandInput;
 
                     if (args[0]) {
@@ -187,7 +187,7 @@ class GEventHandling {
 
                             if (subcommandInput.timeLimit) return message.reply(this.client.languageFile.ARGS_TIME_LIMIT[guildLanguage]);
                         } else {
-                            subcommandInput = { content: cmdSubcommands.find(sc => sc.name === args[0].toLowerCase()) };
+                            subcommandInput = { content: arg.get(args[0]) };
                         }
                     } else {
                         subcommandInput = await arg.obtain(message);
@@ -255,13 +255,13 @@ class GEventHandling {
                                 }
                             }
                         } else {
-                            finalArgs.push(rawArg);
+                            finalArgs.push(arg.get(rawArg));
 
-                            if (ifNotSubOrGroup) objectArgs.push({ name: arg.name, value: rawArg, type: arg.type });
+                            if (ifNotSubOrGroup) objectArgs.push({ name: arg.name, value: arg.get(rawArg), type: arg.type });
 
                             for (const input of missingInput) {
                                 if (input.name === arg.name) {
-                                    input.value = rawArg;
+                                    input.value = arg.get(rawArg);
                                 }
                             }
                         }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR fixes some issues with arguments not returning the correct value.

`boolean` -> return `boolean` instead of `string`.
`number` -> return `number` instead of `string`.
`intiger` -> return `intiger` instead of `string`.
`role/user/channel/mentionable` -> return `id` even when a mention is used (`string`).

No breaking changes were made to `string/sub_command/sub_command_group`.

**Status and versioning classification:**
- I know how to update typings and have done so, or typings don't need updating
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)