### PR TITLE
feat(delete prompt & delete input): option to delete prompt/input for arguments

### DIFF
--- a/src/base/GCommandsClient.js
+++ b/src/base/GCommandsClient.js
@@ -134,6 +134,20 @@ class GCommandsClient extends Client {
         this.loadFromCache = options.commands.loadFromCache !== undefined ? Boolean(options.commands.loadFromCache) : true;
 
         /**
+         * DeletePrompt
+         * @type {boolean}
+         * @default false
+         */
+        this.deletePrompt = options.arguments.deletePrompt !== undefined ? Boolean(options.arguments.deletePrompt) : false;
+
+        /**
+         * DeleteInput
+         * @type {boolean}
+         * @default false
+         */
+        this.deleteInput = options.arguments.deleteInput !== undefined ? Boolean(options.arguments.deleteInput) : false;
+
+        /**
          * DefaultCooldown
          * @type {number}
          * @default 0

--- a/src/base/GCommandsClient.js
+++ b/src/base/GCommandsClient.js
@@ -138,14 +138,14 @@ class GCommandsClient extends Client {
          * @type {boolean}
          * @default false
          */
-        this.deletePrompt = options.arguments.deletePrompt !== undefined ? Boolean(options.arguments.deletePrompt) : false;
+        this.deletePrompt = options.arguments ? options.arguments.deletePrompt !== undefined ? Boolean(options.arguments.deletePrompt) : false : false;
 
         /**
          * DeleteInput
          * @type {boolean}
          * @default false
          */
-        this.deleteInput = options.arguments.deleteInput !== undefined ? Boolean(options.arguments.deleteInput) : false;
+        this.deleteInput = options.arguments ? options.arguments.deleteInput !== undefined ? Boolean(options.arguments.deleteInput) : false : false;
 
         /**
          * DefaultCooldown

--- a/src/commands/argument.js
+++ b/src/commands/argument.js
@@ -171,7 +171,10 @@ class Argument {
             resFirst.content = resFirst.customId.split('_')[1];
         }
 
-        await msgReply.edit({ content: msgReply.content, components: getComponents(true) });
+        if (this.client.deletePrompt) await msgReply.delete();
+        else await msgReply.edit({ content: msgReply.content, components: getComponents(true) });
+
+        if (this.client.deleteInput && resFirst instanceof ButtonInteraction === false && message.channel.permissionsFor(this.client.user.id).has('MANAGE_MESSAGES')) await resFirst.delete();
 
         let invalid;
         let reason;

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -167,6 +167,7 @@ function createEnum(keys) {
  * @property {string} eventDir
  * @property {GCommandsOptionsLanguage} language
  * @property {GCommandsOptionsCommands} commands
+ * @property {GCommandsOptionsArguments} arguments
  * @property {boolean} caseSensitiveCommands
  * @property {boolean} caseSensitivePrefixes
  * @property {string} defaultCooldown
@@ -216,6 +217,13 @@ function createEnum(keys) {
  * @property {string} prefix
  * @property {boolean} loadFromCache
  * @typedef {(object)} GCommandsOptionsCommands
+ */
+
+/**
+ * The GCommandsOptionsArguments
+ * @property {boolean} deletePrompt
+ * @property {boolean} deleteInput
+ * @typedef {(object)} GCommandsOptionsArguments
  */
 
 /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR adds the ability to delete the prompt for arguments and the response of the user.

```js
new GCommandsClient({
 ...options,
 arguments: {
  deletePrompt: true, // Default is false
  deleteInput: true, // Default is false
 }):
```

**Status and versioning classification:**
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)