### PR TITLE
chore(Client): remove refering to client.GCommandsClient

### DIFF
--- a/src/base/GCommandsClient.js
+++ b/src/base/GCommandsClient.js
@@ -23,15 +23,8 @@ class GCommandsClient extends Client {
 
         if (!options.cmdDir) throw new GError('[DEFAULT OPTIONS]','You must specify the cmdDir');
         if (!options.language) throw new GError('[DEFAULT OPTIONS]','You must specify the language');
+        if (!options.commands) throw new GError('[DEFAULT OPTIONS]','You must specify the command options');
         if (String(options.commands.slash) !== 'false' && !options.commands.prefix) throw new GError('[DEFAULT OPTIONS]','You must specify the commands#prefix');
-
-        /**
-         * GCommandsClient
-         * @type {GCommandsClient}
-        */
-        this.GCommandsClient = this;
-        this.GCommandsClient.client = this;
-        this.client = this;
 
         /**
          * CaseSensitiveCommands
@@ -145,9 +138,9 @@ class GCommandsClient extends Client {
          * @type {GCommandsDispatcher}
          * @readonly
          */
-        this.dispatcher = new GCommandsDispatcher(this.GCommandsClient, true);
+        this.dispatcher = new GCommandsDispatcher(this, true);
 
-        new GDatabaseLoader(this.GCommandsClient);
+        new GDatabaseLoader(this);
 
         setImmediate(() => {
             super.on('ready', () => {
@@ -167,9 +160,9 @@ class GCommandsClient extends Client {
         require('../structures/ThreadChannel');
 
         setTimeout(() => {
-            new GEventHandling(this.GCommandsClient);
-            new GEventLoader(this.GCommandsClient);
-            new GCommandLoader(this.GCommandsClient);
+            new GEventHandling(this);
+            new GEventLoader(this);
+            new GCommandLoader(this);
         }, 1000);
     };
 }

--- a/src/base/GCommandsDispatcher.js
+++ b/src/base/GCommandsDispatcher.js
@@ -16,18 +16,12 @@ class GCommandsDispatcher {
      * The GCommansDispatcher class
      * @param {GCommandsClient} GCommandsClient
      */
-    constructor(GCommandsClient, readyWait = true) {
-        /**
-         * GCommandsClient
-         * @type {GCommands}
-        */
-         this.GCommandsClient = GCommandsClient;
-
+    constructor(client, readyWait = true) {
         /**
          * Client
-         * @type {Client}
+         * @type {GCommandsClient}
          */
-        this.client = this.GCommandsClient.client;
+        this.client = client;
 
         /**
          * Inhibitors

--- a/src/managers/GCommandLoader.js
+++ b/src/managers/GCommandLoader.js
@@ -11,26 +11,20 @@ const Command = require('../commands/base');
 class GCommandLoader {
     /**
      * The GCommandLoader class
-     * @param {GCommands} GCommandsClient
+     * @param {GCommandsClient} client
      */
-    constructor(GCommandsClient) {
-        /**
-         * GCommandsClient
-         * @type {GCommands}
-        */
-        this.GCommandsClient = GCommandsClient;
-
+    constructor(client) {
         /**
          * Client
-         * @type {Client}
+         * @type {GCommandsClient}
         */
-        this.client = this.GCommandsClient.client;
+        this.client = client;
 
         /**
          * CmdDir
          * @type {string}
         */
-        this.cmdDir = this.GCommandsClient.cmdDir;
+        this.cmdDir = this.client.cmdDir;
 
         /**
          * All Global Commands
@@ -69,7 +63,7 @@ class GCommandLoader {
 
             this.client.gcommands.set(file.name, file);
             if (file && file.aliases && Array.isArray(file.aliases)) file.aliases.forEach(alias => this.client.galiases.set(alias, file.name));
-            this.GCommandsClient.emit(Events.LOG, new Color(`&d[GCommands] &aLoaded (File): &e➜   &3${fileName}`, { json: false }).getText());
+            this.client.emit(Events.LOG, new Color(`&d[GCommands] &aLoaded (File): &e➜   &3${fileName}`, { json: false }).getText());
         }
 
         await this.__loadSlashCommands();
@@ -106,7 +100,7 @@ class GCommandLoader {
 
             this.client.gcommands.set(file.name, file);
             if (file && file.aliases && Array.isArray(file.aliases)) file.aliases.forEach(alias => this.client.galiases.set(alias, file.name));
-            this.GCommandsClient.emit(Events.LOG, new Color(`&d[GCommands] &aLoaded (File): &e➜   &3${fileName}`, { json: false }).getText());
+            this.client.emit(Events.LOG, new Color(`&d[GCommands] &aLoaded (File): &e➜   &3${fileName}`, { json: false }).getText());
         }
     }
 
@@ -133,7 +127,7 @@ class GCommandLoader {
                     else ifAlready = (await this._allGlobalCommands).filter(c => c.name === cmd.name && c.type === 1);
 
                     if (ifAlready.length > 0 && ((ifAlready[0].default_permission === false && ((Object.values(cmd)[10] || Object.values(cmd)[12]) !== undefined)) || (ifAlready[0].default_permission === true && ((Object.values(cmd)[10] || Object.values(cmd)[12]) === undefined))) && ifAlready[0].description === cmd.description && JSON.stringify(comparable(cmd.args)) === JSON.stringify(comparable(ifAlready[0].options))) { // eslint-disable-line max-len
-                        this.GCommandsClient.emit(Events.LOG, new Color(`&d[GCommands] &aLoaded from cache (Slash): &e➜   &3${cmd.name}`, { json: false }).getText());
+                        this.client.emit(Events.LOG, new Color(`&d[GCommands] &aLoaded from cache (Slash): &e➜   &3${cmd.name}`, { json: false }).getText());
                         return;
                     }
                 }
@@ -156,10 +150,10 @@ class GCommandLoader {
                 };
 
                 axios(config).then(() => {
-                    this.GCommandsClient.emit(Events.LOG, new Color(`&d[GCommands] &aLoaded (Slash): &e➜   &3${cmd.name}`, { json: false }).getText());
+                    this.client.emit(Events.LOG, new Color(`&d[GCommands] &aLoaded (Slash): &e➜   &3${cmd.name}`, { json: false }).getText());
                 })
                     .catch(error => {
-                        this.GCommandsClient.emit(Events.LOG, new Color(`&d[GCommands] ${error.response ? error.response.status === 429 ? `&aWait &e${ms(error.response.data.retry_after * 1000)}` : '' : ''} &c${error} &e(${cmd.name})`, { json: false }).getText());
+                        this.client.emit(Events.LOG, new Color(`&d[GCommands] ${error.response ? error.response.status === 429 ? `&aWait &e${ms(error.response.data.retry_after * 1000)}` : '' : ''} &c${error} &e(${cmd.name})`, { json: false }).getText());
 
                         if (error.response) {
                             if (error.response.status === 429) {
@@ -167,7 +161,7 @@ class GCommandLoader {
                                     this.__tryAgain(cmd, config, 'Slash');
                                 }, (error.response.data.retry_after) * 1000);
                             } else {
-                                this.GCommandsClient.emit(Events.DEBUG, new Color([
+                                this.client.emit(Events.DEBUG, new Color([
                                     '&a----------------------',
                                     '  &d[GCommands Debug] &3',
                                     `&aCode: &b${error.response.data.code}`,
@@ -177,9 +171,9 @@ class GCommandLoader {
                                 ]).getText());
 
                                 if (error.response.data.errors) {
-                                    getAllObjects(this.GCommandsClient, error.response.data.errors);
+                                    getAllObjects(this.client, error.response.data.errors);
 
-                                    this.GCommandsClient.emit(Events.DEBUG, new Color([
+                                    this.client.emit(Events.DEBUG, new Color([
                                         `&a----------------------`,
                                     ]).getText());
                                 }
@@ -225,7 +219,7 @@ class GCommandLoader {
                     else ifAlready = (await this._allGlobalCommands).filter(c => c.name === cmd.name && [2, 3].includes(c.type));
 
                     if (ifAlready.length > 0 && ifAlready[0].name === cmd.name) {
-                        this.GCommandsClient.emit(Events.LOG, new Color(`&d[GCommands] &aLoaded from cache (Context Menu): &e➜   &3${cmd.name}`, { json: false }).getText());
+                        this.client.emit(Events.LOG, new Color(`&d[GCommands] &aLoaded from cache (Context Menu): &e➜   &3${cmd.name}`, { json: false }).getText());
                         return;
                     }
                 }
@@ -245,7 +239,7 @@ class GCommandLoader {
                 };
 
                 axios(config).then(() => {
-                    this.GCommandsClient.emit(Events.LOG, new Color(`&d[GCommands] &aLoaded (Context Menu (user)): &e➜   &3${cmd.name}`, { json: false }).getText());
+                    this.client.emit(Events.LOG, new Color(`&d[GCommands] &aLoaded (Context Menu (user)): &e➜   &3${cmd.name}`, { json: false }).getText());
                     if (type === 4) {
                         config.data = JSON.parse(config.data);
                         config.data.type = 3;
@@ -254,7 +248,7 @@ class GCommandLoader {
                     }
                 })
                     .catch(error => {
-                        this.GCommandsClient.emit(Events.LOG, new Color(`&d[GCommands] ${error.response ? error.response.status === 429 ? `&aWait &e${ms(error.response.data.retry_after * 1000)}` : '' : ''} &c${error} &e(${cmd.name})`, { json: false }).getText());
+                        this.client.emit(Events.LOG, new Color(`&d[GCommands] ${error.response ? error.response.status === 429 ? `&aWait &e${ms(error.response.data.retry_after * 1000)}` : '' : ''} &c${error} &e(${cmd.name})`, { json: false }).getText());
 
                         if (error.response) {
                             if (error.response.status === 429) {
@@ -262,7 +256,7 @@ class GCommandLoader {
                                     this.__tryAgain(cmd, config, 'Context Menu');
                                 }, (error.response.data.retry_after) * 1000);
                             } else {
-                                this.GCommandsClient.emit(Events.DEBUG, new Color([
+                                this.client.emit(Events.DEBUG, new Color([
                                     '&a----------------------',
                                     '  &d[GCommands Debug] &3',
                                     `&aCode: &b${error.response.data.code}`,
@@ -272,9 +266,9 @@ class GCommandLoader {
                                 ]).getText());
 
                                 if (error.response.data.errors) {
-                                    getAllObjects(this.GCommandsClient, error.response.data.errors);
+                                    getAllObjects(this.client, error.response.data.errors);
 
-                                    this.GCommandsClient.emit(Events.DEBUG, new Color([
+                                    this.client.emit(Events.DEBUG, new Color([
                                         `&a----------------------`,
                                     ]).getText());
                                 }
@@ -357,10 +351,10 @@ class GCommandLoader {
                         };
 
                         axios(config).then(() => {
-                            this.GCommandsClient.emit(Events.LOG, new Color(`&d[GCommands] &aLoaded (Permission): &e➜   &3${cmd.name}`, { json: false }).getText());
+                            this.client.emit(Events.LOG, new Color(`&d[GCommands] &aLoaded (Permission): &e➜   &3${cmd.name}`, { json: false }).getText());
                         })
                             .catch(error => {
-                                this.GCommandsClient.emit(Events.LOG, new Color(`&d[GCommands] ${error.response ? error.response.status === 429 ? `&aWait &e${ms(error.response.data.retry_after * 1000)}` : '' : ''} &c${error} &e(${cmd.name})`, { json: false }).getText());
+                                this.client.emit(Events.LOG, new Color(`&d[GCommands] ${error.response ? error.response.status === 429 ? `&aWait &e${ms(error.response.data.retry_after * 1000)}` : '' : ''} &c${error} &e(${cmd.name})`, { json: false }).getText());
 
                                 if (error.response) {
                                     if (error.response.status === 429) {
@@ -368,7 +362,7 @@ class GCommandLoader {
                                             this.__tryAgain(cmd, config, 'Permission');
                                         }, (error.response.data.retry_after) * 1000);
                                     } else {
-                                        this.GCommandsClient.emit(Events.DEBUG, new Color([
+                                        this.client.emit(Events.DEBUG, new Color([
                                             '&a----------------------',
                                             '  &d[GCommands Debug] &3',
                                             `&aCode: &b${error.response.data.code}`,
@@ -378,9 +372,9 @@ class GCommandLoader {
                                         ]).getText());
 
                                         if (error.response.data.errors) {
-                                            getAllObjects(this.GCommandsClient, error.response.data.errors);
+                                            getAllObjects(this.client, error.response.data.errors);
 
-                                            this.GCommandsClient.emit(Events.DEBUG, new Color([
+                                            this.client.emit(Events.DEBUG, new Color([
                                                 `&a----------------------`,
                                             ]).getText());
                                         }
@@ -424,10 +418,10 @@ class GCommandLoader {
     */
     __tryAgain(cmd, config, type) {
         axios(config).then(() => {
-            this.GCommandsClient.emit(Events.LOG, new Color(`&d[GCommands] &aLoaded (${type}): &e➜   &3${cmd.name}`, { json: false }).getText());
+            this.client.emit(Events.LOG, new Color(`&d[GCommands] &aLoaded (${type}): &e➜   &3${cmd.name}`, { json: false }).getText());
         })
             .catch(error => {
-                this.GCommandsClient.emit(Events.LOG, new Color(`&d[GCommands] ${error.response ? error.response.status === 429 ? `&aWait &e${ms(error.response.data.retry_after * 1000)}` : '' : ''} &c${error} &e(${cmd.name})`, { json: false }).getText());
+                this.client.emit(Events.LOG, new Color(`&d[GCommands] ${error.response ? error.response.status === 429 ? `&aWait &e${ms(error.response.data.retry_after * 1000)}` : '' : ''} &c${error} &e(${cmd.name})`, { json: false }).getText());
 
                 if (error.response) {
                     if (error.response.status === 429) {

--- a/src/managers/GDatabaseLoader.js
+++ b/src/managers/GDatabaseLoader.js
@@ -6,20 +6,14 @@ const GError = require('../structures/GError');
 class GDatabaseLoader {
     /**
      * The GDatabaseLoader class
-     * @param {GCommands} GCommandsClient
+     * @param {GCommandsClient} client
     */
-    constructor(GCommandsClient) {
-        /**
-         * GCommandsClient
-         * @type {GCommands}
-        */
-        this.GCommandsClient = GCommandsClient;
-
+    constructor(client) {
         /**
          * Client
-         * @type {Client}
+         * @type {GCommandsClient}
         */
-        this.client = this.GCommandsClient.client;
+        this.client = client;
 
         this.__loadDB();
     }
@@ -30,7 +24,7 @@ class GDatabaseLoader {
      * @private
      */
     __loadDB() {
-        let dbType = this.GCommandsClient.database;
+        let dbType = this.client.database;
         if (!dbType) { this.client.database = undefined; } else {
             try {
                 const Keyv = require('keyv');

--- a/src/managers/GEventHandling.js
+++ b/src/managers/GEventHandling.js
@@ -11,20 +11,14 @@ const ifDjsV13 = require('../util/util').checkDjsVersion('13');
 class GEventHandling {
     /**
      * Creates new GEventHandling instance
-     * @param {GCommandsClient} GCommandsClient
+     * @param {GCommandsClient} client
      */
-    constructor(GCommandsClient) {
-        /**
-         * GCommandsClient
-         * @type {GCommands}
-        */
-        this.GCommandsClient = GCommandsClient;
-
+    constructor(client) {
         /**
          * Client
-         * @type {Client}
+         * @type {GCommandsClient}
         */
-        this.client = GCommandsClient.client;
+        this.client = client;
 
         this.messageEvent();
         this.slashEvent();
@@ -51,7 +45,7 @@ class GEventHandling {
 
             let mentionRegex = new RegExp(`^<@!?(${this.client.user.id})> `);
 
-            let prefix = message.content.match(mentionRegex) ? message.content.match(mentionRegex) : (await message.guild.getCommandPrefix()).filter(p => this.GCommandsClient.caseSensitivePrefixes ? message.content.toLowerCase().slice(0, p.length) === p.toLowerCase() : message.content.slice(0, p.length) === p);
+            let prefix = message.content.match(mentionRegex) ? message.content.match(mentionRegex) : (await message.guild.getCommandPrefix()).filter(p => this.client.caseSensitivePrefixes ? message.content.toLowerCase().slice(0, p.length) === p.toLowerCase() : message.content.slice(0, p.length) === p);
             if (prefix.length === 0) return;
 
             const [cmd, ...args] = message.content.slice(prefix[0].length).trim().split(/ +/g);
@@ -60,11 +54,11 @@ class GEventHandling {
             let commandos;
             try {
                 commandos = this.client.gcommands.get(
-                    !this.GCommandsClient.caseSensitiveCommands ?
+                    !this.client.caseSensitiveCommands ?
                         String(cmd).toLowerCase() :
                         String(cmd.name),
                 ) || this.client.galiases.get(
-                    !this.GCommandsClient.caseSensitiveCommands ?
+                    !this.client.caseSensitiveCommands ?
                         String(cmd).toLowerCase() :
                         String(cmd.name),
                 );
@@ -342,7 +336,7 @@ class GEventHandling {
                 });
             } catch (e) {
                 this.client.emit(Events.COMMAND_ERROR, { command: commandos, member: message.member, channel: message.channel, guild: message.guild, error: e });
-                this.GCommandsClient.emit(Events.DEBUG, e);
+                this.client.emit(Events.DEBUG, e);
             }
         };
     }
@@ -361,7 +355,7 @@ class GEventHandling {
             let commandos;
             try {
                 commandos = this.client.gcommands.find(cmd =>
-                    !this.GCommandsClient.caseSensitiveCommands ?
+                    !this.client.caseSensitiveCommands ?
                         (String(interaction.commandName).toLowerCase() === String(cmd.name).toLowerCase() || String(interaction.commandName).toLowerCase() === String(cmd.contextMenuName).toLowerCase()) :
                         (String(interaction.commandName) === String(cmd.name) || String(interaction.commandName) === String(cmd.contextMenuName)),
                 );
@@ -465,13 +459,13 @@ class GEventHandling {
                     });
                 } catch (e) {
                     this.client.emit(Events.COMMAND_ERROR, { command: commandos, member: interaction.member, channel: interaction.channel, guild: interaction.guild, error: e });
-                    this.GCommandsClient.emit(Events.DEBUG, e);
+                    this.client.emit(Events.DEBUG, e);
                 }
 
                 this.client.emit(Events.COMMAND_EXECUTE, { command: commandos, member: interaction.member, channel: interaction.channel, guild: interaction.guild });
             } catch (e) {
                 this.client.emit(Events.COMMAND_ERROR, { command: commandos, member: interaction.member, channel: interaction.channel, guild: interaction.guild, error: e });
-                this.GCommandsClient.emit(Events.DEBUG, e);
+                this.client.emit(Events.DEBUG, e);
             }
         });
     }

--- a/src/managers/GEventLoader.js
+++ b/src/managers/GEventLoader.js
@@ -8,21 +8,15 @@ class GEventLoader extends null {}
 
 /**
  * GCommandsClient
- * @type {GCommands}
+ * @type {GCommandsClient}
 */
-GEventLoader.GCommandsClient = GEvents.GEvents.GCommandsClient;
+GEventLoader.client = GEvents.GEvents.client;
 
 /**
  * EventDir
  * @type {string}
  */
 GEventLoader.eventDir = GEvents.GEvents.eventDir;
-
-/**
- * Client
- * @type {Client}
- */
-GEventLoader.client = GEvents.GEvents.client;
 
 /**
  * Gevents

--- a/src/util/util.js
+++ b/src/util/util.js
@@ -219,11 +219,11 @@ class Util {
 
     /**
      * GetAllObjects from object
-     * @param {GCommandsClient} GCommandsClient
+     * @param {GCommandsClient} client
      * @param {Object} ob
      * @returns {String}
     */
-    static getAllObjects(GCommandsClient, ob) {
+    static getAllObjects(client, ob) {
 	    if (typeof ob !== 'object') return;
         for (let v of Object.values(ob)) {
             if (Array.isArray(v)) {
@@ -231,7 +231,7 @@ class Util {
             } else if (typeof v === 'object') {
                 Util.getAllObjects(v);
             } else {
-                GCommandsClient.emit(Events.DEBUG, new Color([
+                client.emit(Events.DEBUG, new Color([
                     `&b${v}`,
                 ]).getText());
             }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
**WARNING: THIS CHANGE ALSO AFFECTS GEVENTS, BOTH PR'S SHOULD BE MERGED AT THE SAME TIME**

Changes:
- This PR removes `client.GCommandsClient` associations. This was done because it was just weird how it was used.
- Added a check if `GCommandsClient#commands` exists, and throw an error if not.

**Status and versioning classification:**
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
