### PR TITLE
fix: command & option name regex validating

### DIFF
--- a/src/lib/structures/Argument.ts
+++ b/src/lib/structures/Argument.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import type { AutocompleteContext } from './contexts/AutocompleteContext';
 import { Locale, LocaleString } from '../util/common';
 import { Logger } from '../util/logger/Logger';
+import { commandAndOptionNameRegexp } from '../util/regexes';
 
 export enum ArgumentType {
 	'SUB_COMMAND' = 1,
@@ -62,10 +63,7 @@ export interface ArgumentOptions {
 
 const validationSchema = z
 	.object({
-		name: z
-			.string()
-			.max(32)
-			.regex(/^[a-zA-Z1-9]/),
+		name: z.string().max(32).regex(commandAndOptionNameRegexp),
 		nameLocalizations: z
 			.record(
 				z
@@ -75,10 +73,7 @@ const validationSchema = z
 							? Locale[arg]
 							: arg,
 					),
-				z
-					.string()
-					.max(32)
-					.regex(/^[a-zA-Z1-9]/),
+				z.string().max(32).regex(commandAndOptionNameRegexp),
 			)
 			.optional(),
 		description: z.string().max(100),
@@ -114,10 +109,7 @@ const validationSchema = z
 									? Locale[arg]
 									: arg,
 							),
-						z
-							.string()
-							.max(32)
-							.regex(/^[a-zA-Z1-9]/),
+						z.string().max(32).regex(commandAndOptionNameRegexp),
 					)
 					.optional(),
 				value: z.string(),

--- a/src/lib/structures/Command.ts
+++ b/src/lib/structures/Command.ts
@@ -5,6 +5,7 @@ import { AutoDeferType, GClient } from '../GClient';
 import { Commands } from '../managers/CommandManager';
 import { Locale, LocaleString } from '../util/common';
 import { Logger } from '../util/logger/Logger';
+import { commandAndOptionNameRegexp } from '../util/regexes';
 
 export enum CommandType {
 	/**
@@ -48,10 +49,7 @@ export interface CommandOptions {
 
 const validationSchema = z
 	.object({
-		name: z
-			.string()
-			.max(32)
-			.regex(/^[aA-zZ1-9]/),
+		name: z.string().max(32).regex(commandAndOptionNameRegexp),
 		nameLocalizations: z
 			.record(
 				z
@@ -61,10 +59,7 @@ const validationSchema = z
 							? Locale[arg]
 							: arg,
 					),
-				z
-					.string()
-					.max(32)
-					.regex(/^[a-zA-Z1-9]/),
+				z.string().max(32).regex(commandAndOptionNameRegexp),
 			)
 			.optional(),
 		description: z.string().max(100).optional(),

--- a/src/lib/util/regexes.ts
+++ b/src/lib/util/regexes.ts
@@ -1,4 +1,9 @@
+/**
+ * Regexes for arguments
+ */
 export const userRegexp = /^(?:<@!?)?([0-9]+)>?$/;
 export const roleRegexp = /^(?:<@&)?([0-9]+)>?$/;
 export const channelRegexp = /^(?:<#)?([0-9]+)>?$/;
 export const mentionableRegexp = /^(?:<@!?)?(?:<@&?)?([0-9]+)>?$/;
+
+export const commandAndOptionNameRegexp = /^[\P{Lu}\p{N}_-]+$/u;

--- a/src/lib/util/regexes.ts
+++ b/src/lib/util/regexes.ts
@@ -1,9 +1,35 @@
 /**
  * Regexes for arguments
  */
+
+/**
+ * Regex for user argument type that matches users by id
+ * @raw `/^(?:<@!?)?([0-9]+)>?$/`
+ */
 export const userRegexp = /^(?:<@!?)?([0-9]+)>?$/;
+
+/**
+ * Regex for role argument type that matches roles by id
+ * @raw `/^(?:<@&)?([0-9]+)>?$/
+ */
 export const roleRegexp = /^(?:<@&)?([0-9]+)>?$/;
+
+/**
+ * Regex for channel argument type that matches channels by id
+ * @raw `/^(?:<#)?([0-9]+)>?$/`
+ */
 export const channelRegexp = /^(?:<#)?([0-9]+)>?$/;
+
+/**
+ * Regex for mentionable argument type
+ * @see {@link userRegexp} for user argument type
+ * @see {@link roleRegexp} for role argument type
+ * @raw `/^(?:<@!?)?(?:<@&?)?([0-9]+)>?$/`
+ */
 export const mentionableRegexp = /^(?:<@!?)?(?:<@&?)?([0-9]+)>?$/;
 
+/**
+ * Regex for command and option names
+ * @raw `/^[\P{Lu}\p{N}_-]+$/u`
+ */
 export const commandAndOptionNameRegexp = /^[\P{Lu}\p{N}_-]+$/u;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Validating command name & option with regex before `PUT` request
Regex `^[-_\p{L}\p{N}\p{sc=Deva}\p{sc=Thai}]{1,32}$` - https://discord.com/developers/docs/interactions/application-commands


**Status and versioning classification:**
- This PR changes the library's interface (methods or parameters added)

<!--
Please move lines that apply to you out of the comment:
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
