### PR TITLE
fix: add {duration} variable

### DIFF
--- a/src/handlers/ComponentHandler.ts
+++ b/src/handlers/ComponentHandler.ts
@@ -37,12 +37,12 @@ export async function ComponentHandler(
 		if (cooldown) {
 			return interaction.reply({
 				content: (await Util.getResponse('COOLDOWN', interaction))
-					.replace('{time}', String(cooldown))
-					.replace(
-						'{name}',
-						component.name +
-							(interaction.isButton() ? ' button' : ' select menu'),
-					),
+					/**
+					 * @deprecated Use {duration} instead
+					 */
+					.replaceAll('{time}', String(cooldown))
+					.replaceAll('{duration}', String(cooldown))
+					.replaceAll('{name}', component.name),
 				ephemeral: true,
 			});
 		}

--- a/src/handlers/InteractionCommandHandler.ts
+++ b/src/handlers/InteractionCommandHandler.ts
@@ -36,8 +36,12 @@ export async function InteractionCommandHandler(
 		if (cooldown) {
 			return interaction.reply({
 				content: (await Util.getResponse('COOLDOWN', interaction))
-					.replace('{time}', String(cooldown))
-					.replace('{name}', `${command.name} command`),
+					/**
+					 * @deprecated Use {duration} instead
+					 */
+					.replaceAll('{time}', String(cooldown))
+					.replaceAll('{duration}', String(cooldown))
+					.replaceAll('{name}', command.name),
 				ephemeral: true,
 			});
 		}

--- a/src/handlers/MessageCommandHandler.ts
+++ b/src/handlers/MessageCommandHandler.ts
@@ -162,8 +162,12 @@ export async function MessageCommandHandler(
 		if (cooldown) {
 			return message.reply({
 				content: (await Util.getResponse('COOLDOWN', { client }))
-					.replace('{time}', String(cooldown))
-					.replace('{name}', `${command.name} command`),
+					/**
+					 * @deprecated Use {duration} instead
+					 */
+					.replaceAll('{time}', String(cooldown))
+					.replaceAll('{duration}', String(cooldown))
+					.replaceAll('{name}', command.name),
 			});
 		}
 	}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
In the `@gcommands/plugin-cooldowns` plugin, the name of the variabble is `{duration}` and hence they take up a bit of residence. Also, a much better name is `duration` because it is a remnant (cooldown) of time and not time.

**Status and versioning classification:**
- This PR changes the library's interface (methods or parameters added)

<!--
Please move lines that apply to you out of the comment:
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
