### PR TITLE
fix(Argument): choice value should allow numbers

### DIFF
--- a/src/lib/structures/Argument.ts
+++ b/src/lib/structures/Argument.ts
@@ -110,7 +110,6 @@ const validationSchema = z
 									: arg,
 							),
 						z.string().max(32).regex(commandAndOptionNameRegexp),
-						z.number(),
 					)
 					.optional(),
 				value: z.union([z.string(), z.number()]),

--- a/src/lib/structures/Argument.ts
+++ b/src/lib/structures/Argument.ts
@@ -34,7 +34,7 @@ export enum ChannelType {
 export interface ArgumentChoice {
 	name: string;
 	nameLocalizations?: Record<LocaleString, string>;
-	value: string;
+	value: string | number;
 }
 
 export interface ArgumentOptions {
@@ -110,9 +110,10 @@ const validationSchema = z
 									: arg,
 							),
 						z.string().max(32).regex(commandAndOptionNameRegexp),
+						z.number(),
 					)
 					.optional(),
-				value: z.string(),
+				value: z.union([z.string(), z.number()]),
 			})
 			.array()
 			.optional(),


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR fixes an issue where argument choices would not accept numbers as a value, even tho they should.

**Status and versioning classification:**
