### PR TITLE
fix: types CacheType should not be undefined

### DIFF
--- a/src/lib/structures/contexts/AutocompleteContext.ts
+++ b/src/lib/structures/contexts/AutocompleteContext.ts
@@ -24,7 +24,7 @@ export class AutocompleteContext<
 	public readonly argumentName: string;
 	public readonly value: string | number;
 	public respond: (choices: Array<ArgumentChoice>) => Promise<void>;
-	public inGuild: () => this is AutocompleteContext<undefined>;
+	public inGuild: () => this is AutocompleteContext<'raw' | 'cached'>;
 	public inCachedGuild: () => this is AutocompleteContext<'cached'>;
 	public inRawGuild: () => this is AutocompleteContext<'raw'>;
 

--- a/src/lib/structures/contexts/CommandContext.ts
+++ b/src/lib/structures/contexts/CommandContext.ts
@@ -69,7 +69,7 @@ export class CommandContext<
 			| MessagePayload
 			| InteractionReplyOptions,
 	) => Promise<Fetch extends true ? GuildCacheMessage<Cached> : void>;
-	public inGuild: () => this is CommandContext<undefined>;
+	public inGuild: () => this is CommandContext<'raw' | 'cached'>;
 	public inCachedGuild: () => this is CommandContext<'cached'>;
 	public inRawGuild: () => this is CommandContext<'raw'>;
 

--- a/src/lib/structures/contexts/ComponentContext.ts
+++ b/src/lib/structures/contexts/ComponentContext.ts
@@ -79,7 +79,7 @@ export class ComponentContext<
 			| MessagePayload
 			| InteractionReplyOptions,
 	) => Promise<Fetch extends true ? GuildCacheMessage<Cached> : void>;
-	public inGuild: () => this is ComponentContext<undefined>;
+	public inGuild: () => this is ComponentContext<'raw' | 'cached'>;
 	public inCachedGuild: () => this is ComponentContext<'cached'>;
 	public inRawGuild: () => this is ComponentContext<'raw'>;
 

--- a/src/lib/structures/contexts/Context.ts
+++ b/src/lib/structures/contexts/Context.ts
@@ -71,7 +71,7 @@ export class Context<Cached extends CacheType = CacheType> {
 		this.memberPermissions = options.memberPermissions;
 	}
 
-	public inGuild(): this is Context<undefined> {
+	public inGuild(): this is Context<'raw' | 'cached'> {
 		return Boolean(this.guildId && this.member);
 	}
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
There was a mistake in #457 where CacheType was set as undefined, but should be `'raw' | 'cached'`
